### PR TITLE
Report errors from (unbound) lambdas when the enclosing invocation fails

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -22,7 +22,7 @@
   <Target Name="Build">
     <MSBuild BuildInParallel="true"
              Projects="$(RoslynSolution)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=false"
+             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
              Targets="Build"/>
     <MSBuild BuildInParallel="true"
              Condition="'$(ManualTest)' == ''"
@@ -34,7 +34,7 @@
   <Target Name="Clean">
     <MSBuild BuildInParallel="true"
              Projects="$(RoslynSolution)"
-             Properties="RestorePackages=false;DeployExtension=false"
+             Properties="RestorePackages=false"
              Targets="Clean"/>
     <MSBuild BuildInParallel="true"
              Condition="'$(ManualTest)' == ''"
@@ -46,7 +46,7 @@
   <Target Name="Rebuild">
     <MSBuild BuildInParallel="true"
              Projects="$(RoslynSolution)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=false"
+             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
              Targets="Rebuild"/>
     <MSBuild BuildInParallel="true"
              Condition="'$(ManualTest)' == ''"

--- a/src/Compilers/CSharp/Portable/Binder/Binder.WithQueryLambdaParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.WithQueryLambdaParametersBinder.cs
@@ -72,10 +72,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // We only construct transparent query variables using anonymous types, so if we're trying to navigate through
                     // some other type, we must have some query API where the types don't match up as expected.
-                    // We should report this as an error of some sort.
-                    // TODO: DevDiv #737822 - reword error message and add test.
                     var info = new CSDiagnosticInfo(ErrorCode.ERR_UnsupportedTransparentIdentifierAccess, name, receiver.ExpressionSymbol ?? receiverType);
-                    Error(diagnostics, info, node);
+                    if (receiver.Type?.IsErrorType() != true)
+                    {
+                        Error(diagnostics, info, node);
+                    }
+
                     return new BoundBadExpression(
                         node,
                         LookupResultKind.Empty,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -713,11 +713,23 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!result.Succeeded)
             {
-                // If the arguments had an error reported about them then suppress further error
-                // reporting for overload resolution. 
-
-                if (!analyzedArguments.HasErrors)
+                if (analyzedArguments.HasErrors)
                 {
+                    // Errors for arguments have already been reported, except for unbound lambdas.
+                    // We report those now.
+                    foreach (var argument in analyzedArguments.Arguments)
+                    {
+                        var unboundLambda = argument as UnboundLambda;
+                        if (unboundLambda != null)
+                        {
+                            var boundWithErrors = unboundLambda.BindForErrorRecovery();
+                            diagnostics.AddRange(boundWithErrors.Diagnostics);
+                        }
+                    }
+                }
+                else
+                {
+                    // Since there were no argument errors to report, we report an error on the invocation itself.
                     string name = (object)delegateTypeOpt == null ? methodName : null;
                     result.ReportDiagnostics(this, GetLocationForOverloadResolutionDiagnostic(node, expression), diagnostics, name,
                         methodGroup.Receiver, analyzedArguments, methodGroup.Methods.ToImmutable(),

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     // The null pointer is represented as 0u.
                     _builder.EmitIntConstant(0);
                     _builder.EmitOpCode(ILOpCode.Conv_u);
+                    EmitPopIfUnused(used);
                     return;
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var arg = node.Indices[0];
                 var index = Visit(arg);
-                if (node.Type != _int32Type)
+                if (index.Type != _int32Type)
                 {
                     index = ConvertIndex(index, arg.Type, _int32Type);
                 }
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var arg in expressions)
             {
                 var index = Visit(arg);
-                if (arg.Type != _int32Type)
+                if (index.Type != _int32Type)
                 {
                     index = ConvertIndex(index, arg.Type, _int32Type);
                 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -9194,6 +9194,29 @@ public unsafe class C
             var result = CompileAndVerify(compilation, expectedOutput: "5");
         }
 
+
+        [Fact, WorkItem(7550, "https://github.com/dotnet/roslyn/issues/7550")]
+        public void EnsureNullPointerIsPoppedIfUnused()
+        {
+            string source = @"
+public class A
+{
+    public unsafe byte* Ptr;
+
+    static void Main()
+    {
+        unsafe
+        {
+            var x = new A();
+            byte* ptr = (x == null) ? null : x.Ptr;
+        }
+        System.Console.WriteLine(""OK"");
+    }
+}
+";
+            CompileAndVerify(source, options: TestOptions.UnsafeReleaseExe, expectedOutput: "OK");
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -1465,5 +1465,99 @@ namespace RoslynAsyncDelegate
 
             CompileAndVerify(compilation);
         }
+
+        [Fact]
+        [WorkItem(1867, "https://github.com/dotnet/roslyn/issues/1867")]
+        public void TestLambdaWithError01()
+        {
+            var source =
+@"using System.Linq;
+class C { C() { string.Empty.Select(() => { new Unbound1 }); } }";
+            CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+    // (2,58): error CS1526: A new expression requires (), [], or {} after type
+    // class C { C() { string.Empty.Select(() => { new Unbound1 }); } }
+    Diagnostic(ErrorCode.ERR_BadNewExpr, "}").WithLocation(2, 58),
+    // (2,58): error CS1002: ; expected
+    // class C { C() { string.Empty.Select(() => { new Unbound1 }); } }
+    Diagnostic(ErrorCode.ERR_SemicolonExpected, "}").WithLocation(2, 58),
+    // (2,49): error CS0246: The type or namespace name 'Unbound1' could not be found (are you missing a using directive or an assembly reference?)
+    // class C { C() { string.Empty.Select(() => { new Unbound1 }); } }
+    Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Unbound1").WithArguments("Unbound1").WithLocation(2, 49)
+                );
+        }
+
+        [Fact]
+        [WorkItem(1867, "https://github.com/dotnet/roslyn/issues/1867")]
+        public void TestLambdaWithError02()
+        {
+            var source =
+@"using System.Linq;
+class C { C() { string.Empty.Select(() => { new Unbound1 ( ) }); } }";
+            CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+    // (2,62): error CS1002: ; expected
+    // class C { C() { string.Empty.Select(() => { new Unbound1 ( ) }); } }
+    Diagnostic(ErrorCode.ERR_SemicolonExpected, "}").WithLocation(2, 62),
+    // (2,49): error CS0246: The type or namespace name 'Unbound1' could not be found (are you missing a using directive or an assembly reference?)
+    // class C { C() { string.Empty.Select(() => { new Unbound1 ( ) }); } }
+    Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Unbound1").WithArguments("Unbound1").WithLocation(2, 49)
+                );
+        }
+
+        [Fact]
+        [WorkItem(1867, "https://github.com/dotnet/roslyn/issues/1867")]
+        public void TestLambdaWithError03()
+        {
+            var source =
+@"using System.Linq;
+class C { C() { string.Empty.Select(x => Unbound1, Unbound2 Unbound2); } }";
+            CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+    // (2,61): error CS1003: Syntax error, ',' expected
+    // class C { C() { string.Empty.Select(x => Unbound1, Unbound2 Unbound2); } }
+    Diagnostic(ErrorCode.ERR_SyntaxError, "Unbound2").WithArguments(",", "").WithLocation(2, 61),
+    // (2,52): error CS0103: The name 'Unbound2' does not exist in the current context
+    // class C { C() { string.Empty.Select(x => Unbound1, Unbound2 Unbound2); } }
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "Unbound2").WithArguments("Unbound2").WithLocation(2, 52),
+    // (2,61): error CS0103: The name 'Unbound2' does not exist in the current context
+    // class C { C() { string.Empty.Select(x => Unbound1, Unbound2 Unbound2); } }
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "Unbound2").WithArguments("Unbound2").WithLocation(2, 61),
+    // (2,42): error CS0103: The name 'Unbound1' does not exist in the current context
+    // class C { C() { string.Empty.Select(x => Unbound1, Unbound2 Unbound2); } }
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "Unbound1").WithArguments("Unbound1").WithLocation(2, 42)
+                );
+        }
+
+        [Fact]
+        [WorkItem(1867, "https://github.com/dotnet/roslyn/issues/1867")]
+        public void TestLambdaWithError04()
+        {
+            var source =
+@"using System.Linq;
+class C { C() { string.Empty.Select(x => Unbound1, Unbound2); } }";
+            CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+    // (2,52): error CS0103: The name 'Unbound2' does not exist in the current context
+    // class C { C() { string.Empty.Select(x => Unbound1, Unbound2); } }
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "Unbound2").WithArguments("Unbound2").WithLocation(2, 52),
+    // (2,42): error CS0103: The name 'Unbound1' does not exist in the current context
+    // class C { C() { string.Empty.Select(x => Unbound1, Unbound2); } }
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "Unbound1").WithArguments("Unbound1").WithLocation(2, 42)
+                );
+        }
+
+        [Fact]
+        [WorkItem(1867, "https://github.com/dotnet/roslyn/issues/1867")]
+        public void TestLambdaWithError05()
+        {
+            var source =
+@"using System.Linq;
+class C { C() { Unbound2.Select(x => Unbound1); } }";
+            CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+    // (2,17): error CS0103: The name 'Unbound2' does not exist in the current context
+    // class C { C() { Unbound2.Select(x => Unbound1); } }
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "Unbound2").WithArguments("Unbound2").WithLocation(2, 17),
+    // (2,38): error CS0103: The name 'Unbound1' does not exist in the current context
+    // class C { C() { Unbound2.Select(x => Unbound1); } }
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "Unbound1").WithArguments("Unbound1").WithLocation(2, 38)
+                );
+        }
     }
 }

--- a/src/EditorFeatures/CSharp/BraceMatching/CSharpDirectiveTriviaBraceMatcher.cs
+++ b/src/EditorFeatures/CSharp/BraceMatching/CSharpDirectiveTriviaBraceMatcher.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
 {
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
         RegionDirectiveTriviaSyntax, EndRegionDirectiveTriviaSyntax>
     {
         internal override List<DirectiveTriviaSyntax> GetMatchingConditionalDirectives(DirectiveTriviaSyntax directive, CancellationToken cancellationToken)
-                 => directive.GetMatchingConditionalDirectives(cancellationToken).ToList();
+                => directive.GetMatchingConditionalDirectives(cancellationToken)?.ToList();
 
         internal override DirectiveTriviaSyntax GetMatchingDirective(DirectiveTriviaSyntax directive, CancellationToken cancellationToken)
                 => directive.GetMatchingDirective(cancellationToken);

--- a/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
+++ b/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
@@ -699,5 +699,53 @@ public class C
 
             await TestAsync(code, expected);
         }
+
+        [WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUnmatchedConditionalDirective()
+        {
+            var code = @"
+class Program
+{
+    static void Main(string[] args)
+    {#if$$
+
+    }
+}";
+            var expected = @"
+class Program
+{
+    static void Main(string[] args)
+    {#if
+
+    }
+}";
+
+            await TestAsync(code, expected);
+        }
+
+        [WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUnmatchedConditionalDirective2()
+        {
+            var code = @"
+class Program
+{
+    static void Main(string[] args)
+    {#else$$
+
+    }
+}";
+            var expected = @"
+class Program
+{
+    static void Main(string[] args)
+    {#else
+
+    }
+}";
+
+            await TestAsync(code, expected);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -42,10 +42,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
                 var extensionManager = workspace.Services.GetService<IExtensionManager>();
 
                 var results = new List<ClassifiedSpan>();
-                service.AddSemanticClassificationsAsync(document, textSpan,
+                await service.AddSemanticClassificationsAsync(document, textSpan,
                     extensionManager.CreateNodeExtensionGetter(classifiers, c => c.SyntaxNodeTypes),
                     extensionManager.CreateTokenExtensionGetter(classifiers, c => c.SyntaxTokenKinds),
-                    results, CancellationToken.None).Wait();
+                    results, CancellationToken.None);
 
                 return results;
             }

--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -34,10 +34,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
 
                 var semanticClassifications = new List<ClassifiedSpan>();
                 var syntacticClassifications = new List<ClassifiedSpan>();
-                service.AddSemanticClassificationsAsync(document, textSpan,
+                await service.AddSemanticClassificationsAsync(document, textSpan,
                     extensionManager.CreateNodeExtensionGetter(classifiers, c => c.SyntaxNodeTypes),
                     extensionManager.CreateTokenExtensionGetter(classifiers, c => c.SyntaxTokenKinds),
-                    semanticClassifications, CancellationToken.None).Wait();
+                    semanticClassifications, CancellationToken.None);
                 service.AddSyntacticClassifications(syntaxTree, textSpan, syntacticClassifications, CancellationToken.None);
 
                 var classificationsSpans = new HashSet<TextSpan>();

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
@@ -138,7 +138,7 @@ text;
                 var document = workspace.CurrentSolution.GetDocument(documentId);
                 var position = hostDocument.CursorPosition.Value;
 
-                var completionList = GetCompletionList(document, position, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo());
+                var completionList = await GetCompletionListAsync(document, position, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo());
                 var item = completionList.Items.First(i => i.DisplayText.StartsWith(textTypedSoFar));
 
                 var optionService = workspace.Services.GetService<IOptionService>();
@@ -206,7 +206,7 @@ text;
                 var document = workspace.CurrentSolution.GetDocument(documentId);
                 var position = hostDocument.CursorPosition.Value;
 
-                var completionList = GetCompletionList(document, position, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo());
+                var completionList = await GetCompletionListAsync(document, position, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo());
                 var item = completionList.Items.First(i => i.DisplayText.StartsWith(textTypedSoFar));
 
                 var completionService = document.Project.LanguageServices.GetService<ICompletionService>();

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -434,7 +434,7 @@ class C
                 var provider = new CrefCompletionProvider();
                 var hostDocument = workspace.DocumentWithCursor;
                 var document = workspace.CurrentSolution.GetDocument(hostDocument.Id);
-                var completionList = GetCompletionList(provider, document, hostDocument.CursorPosition.Value, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo());
+                var completionList = await GetCompletionListAsync(provider, document, hostDocument.CursorPosition.Value, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo());
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -576,7 +576,7 @@ class d
                 var document = workspace.CurrentSolution.GetDocument(hostDocument.Id);
                 var triggerInfo = CompletionTriggerInfo.CreateTypeCharTriggerInfo('a');
 
-                var completionList = GetCompletionList(document, position, triggerInfo);
+                var completionList = await GetCompletionListAsync(document, position, triggerInfo);
                 var item = completionList.Items.First();
 
                 var completionService = document.Project.LanguageServices.GetService<ICompletionService>();
@@ -752,7 +752,7 @@ class Container
                 var document = workspace.CurrentSolution.GetDocument(hostDocument.Id);
                 var triggerInfo = CompletionTriggerInfo.CreateTypeCharTriggerInfo('a');
 
-                var completionList = GetCompletionList(document, position, triggerInfo);
+                var completionList = await GetCompletionListAsync(document, position, triggerInfo);
 
                 if (completionList != null)
                 {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -2134,7 +2134,7 @@ End Class
                 var document = solution.GetDocument(documentId);
                 var triggerInfo = new CompletionTriggerInfo();
 
-                var completionList = GetCompletionList(document, position, triggerInfo);
+                var completionList = await GetCompletionListAsync(document, position, triggerInfo);
                 var completionItem = completionList.Items.First(i => CompareItems(i.DisplayText, "Bar[int bay]"));
 
                 var customCommitCompletionProvider = CompletionProvider as ICustomCommitCompletionProvider;
@@ -2393,7 +2393,7 @@ int bar;
                 var document = solution.GetDocument(documentId);
                 var triggerInfo = new CompletionTriggerInfo();
 
-                var completionList = GetCompletionList(document, position, triggerInfo);
+                var completionList = await GetCompletionListAsync(document, position, triggerInfo);
                 var completionItem = completionList.Items.First(i => CompareItems(i.DisplayText, "Equals(object obj)"));
 
                 var customCommitCompletionProvider = CompletionProvider as ICustomCommitCompletionProvider;
@@ -2451,7 +2451,7 @@ int bar;
                 var document = solution.GetDocument(documentId);
                 var triggerInfo = new CompletionTriggerInfo();
 
-                var completionList = GetCompletionList(document, cursorPosition, triggerInfo);
+                var completionList = await GetCompletionListAsync(document, cursorPosition, triggerInfo);
                 var completionItem = completionList.Items.First(i => CompareItems(i.DisplayText, "Equals(object obj)"));
 
                 var customCommitCompletionProvider = CompletionProvider as ICustomCommitCompletionProvider;
@@ -2553,7 +2553,7 @@ namespace ConsoleApplication46
             var provider = new OverrideCompletionProvider(TestWaitIndicator.Default);
             var testDocument = workspace.Documents.Single();
             var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
-            var completionList = GetCompletionList(provider, document, testDocument.CursorPosition.Value, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo());
+            var completionList = await GetCompletionListAsync(provider, document, testDocument.CursorPosition.Value, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo());
 
             var oldTree = await document.GetSyntaxTreeAsync(CancellationToken.None);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -2555,7 +2555,7 @@ namespace ConsoleApplication46
             var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
             var completionList = await GetCompletionListAsync(provider, document, testDocument.CursorPosition.Value, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo());
 
-            var oldTree = await document.GetSyntaxTreeAsync(CancellationToken.None);
+            var oldTree = await document.GetSyntaxTreeAsync();
 
             provider.Commit(completionList.Items.First(i => i.DisplayText == "ToString()"), testDocument.GetTextView(), testDocument.GetTextBuffer(), testDocument.TextBuffer.CurrentSnapshot, ' ');
             var newTree = await workspace.CurrentSolution.GetDocument(testDocument.Id).GetSyntaxTreeAsync();

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
@@ -567,20 +567,20 @@ class a
             using (var workspaceFixture = new CSharpTestWorkspaceFixture())
             {
                 var document1 = await workspaceFixture.UpdateDocumentAsync(code, SourceCodeKind.Regular);
-                CheckResults(document1, position, isBuilder);
+                await CheckResultsAsync(document1, position, isBuilder);
 
                 if (CanUseSpeculativeSemanticModel(document1, position))
                 {
                     var document2 = await workspaceFixture.UpdateDocumentAsync(code, SourceCodeKind.Regular, cleanBeforeUpdate: false);
-                    CheckResults(document2, position, isBuilder);
+                    await CheckResultsAsync(document2, position, isBuilder);
                 }
             }
         }
 
-        private void CheckResults(Document document, int position, bool isBuilder)
+        private async Task CheckResultsAsync(Document document, int position, bool isBuilder)
         {
             var triggerInfo = CompletionTriggerInfo.CreateTypeCharTriggerInfo('a');
-            var completionList = GetCompletionList(document, position, triggerInfo);
+            var completionList = await GetCompletionListAsync(document, position, triggerInfo);
 
             if (isBuilder)
             {

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -161,8 +161,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
                 Assert.NotNull(document);
 
                 var semanticDocument = await SemanticDocument.CreateAsync(document, CancellationToken.None);
-                var tree = await document.GetSyntaxTreeAsync();
-                var iterator = tree.GetRoot().DescendantNodesAndSelf().Cast<SyntaxNode>();
+                var root = await document.GetSyntaxRootAsync();
+                var iterator = root.DescendantNodesAndSelf().Cast<SyntaxNode>();
 
                 var options = document.Project.Solution.Workspace.Options
                                       .WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, true);

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
 
                 options = options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTab);
 
-                var root = syntaxTree.GetRoot();
+                var root = await syntaxTree.GetRootAsync();
                 var rules = formattingRuleProvider.CreateRule(workspace.CurrentSolution.GetDocument(syntaxTree), 0).Concat(Formatter.GetDefaultFormattingRules(workspace, root.Language));
 
                 AssertFormat(workspace, expected, options, rules, clonedBuffer, root);
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
                     }
                 }
 
-                var root = syntaxTree.GetRoot();
+                var root = await syntaxTree.GetRootAsync();
                 var rules = formattingRuleProvider.CreateRule(workspace.CurrentSolution.GetDocument(syntaxTree), 0).Concat(Formatter.GetDefaultFormattingRules(workspace, root.Language));
                 AssertFormat(workspace, expected, options, rules, clonedBuffer, root, spans);
 

--- a/src/EditorFeatures/CSharpTest/LineSeparators/LineSeparatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/LineSeparators/LineSeparatorTests.cs
@@ -534,7 +534,7 @@ class Program
             using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(contents, options))
             {
                 var document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id);
-                var spans = await new CSharpLineSeparatorService().GetLineSeparatorsAsync(document, (await document.GetSyntaxTreeAsync()).GetRoot().FullSpan, CancellationToken.None);
+                var spans = await new CSharpLineSeparatorService().GetLineSeparatorsAsync(document, (await document.GetSyntaxRootAsync()).FullSpan, CancellationToken.None);
                 var tokens = (await document.GetSyntaxRootAsync(CancellationToken.None)).DescendantTokens().Where(t => t.Kind() == SyntaxKind.CloseBraceToken || t.Kind() == SyntaxKind.SemicolonToken);
 
                 Assert.Equal(tokenIndices.Length, spans.Count());

--- a/src/EditorFeatures/CSharpTest/Outlining/CommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/CommentTests.cs
@@ -16,24 +16,24 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        internal override Task<OutliningSpan[]> GetRegionsAsync(Document document, int position)
+        internal override async Task<OutliningSpan[]> GetRegionsAsync(Document document, int position)
         {
-            var root = document.GetSyntaxRootAsync(CancellationToken.None).Result;
+            var root = await document.GetSyntaxRootAsync();
             var trivia = root.FindTrivia(position, findInsideTrivia: true);
 
             var token = trivia.Token;
 
             if (token.LeadingTrivia.Contains(trivia))
             {
-                return Task.FromResult(CSharpOutliningHelpers.CreateCommentRegions(token.LeadingTrivia).ToArray());
+                return CSharpOutliningHelpers.CreateCommentRegions(token.LeadingTrivia).ToArray();
             }
             else if (token.TrailingTrivia.Contains(trivia))
             {
-                return Task.FromResult(CSharpOutliningHelpers.CreateCommentRegions(token.TrailingTrivia).ToArray());
+                return CSharpOutliningHelpers.CreateCommentRegions(token.TrailingTrivia).ToArray();
             }
             else
             {
-                return Task.FromResult(Contract.FailWithReturn<OutliningSpan[]>());
+                return Contract.FailWithReturn<OutliningSpan[]>();
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TodoComment
                 var document = workspace.Documents.First();
                 var documentId = document.Id;
                 var reasons = new InvocationReasons(PredefinedInvocationReasons.DocumentAdded);
-                worker.AnalyzeSyntaxAsync(workspace.CurrentSolution.GetDocument(documentId), CancellationToken.None).Wait();
+                await worker.AnalyzeSyntaxAsync(workspace.CurrentSolution.GetDocument(documentId), CancellationToken.None);
 
                 var todoLists = worker.GetItems_TestingOnly(documentId);
                 var expectedLists = document.SelectedSpans;

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.Delegate.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.Delegate.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TypeInferrer
 
             Document document = await fixture.UpdateDocumentAsync(text, SourceCodeKind.Regular);
 
-            var root = (await document.GetSyntaxTreeAsync()).GetRoot();
+            var root = await document.GetSyntaxRootAsync();
             var node = FindExpressionSyntaxFromSpan(root, textSpan);
 
             var typeInference = document.GetLanguageService<ITypeInferenceService>();

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TypeInferrer
 
         protected override async Task TestWorkerAsync(Document document, TextSpan textSpan, string expectedType, bool useNodeStartPosition)
         {
-            var root = (await document.GetSyntaxTreeAsync()).GetRoot();
+            var root = await document.GetSyntaxRootAsync();
             var node = FindExpressionSyntaxFromSpan(root, textSpan);
             var typeInference = document.GetLanguageService<ITypeInferenceService>();
 

--- a/src/EditorFeatures/Core/Extensibility/BraceMatching/AbstractDirectiveTriviaBraceMatcher.cs
+++ b/src/EditorFeatures/Core/Extensibility/BraceMatching/AbstractDirectiveTriviaBraceMatcher.cs
@@ -36,12 +36,15 @@ namespace Microsoft.CodeAnalysis.Editor
                 return null;
             }
 
-            TDirectiveTriviaSyntax matchingDirective;
+            TDirectiveTriviaSyntax matchingDirective = null;
             if (IsConditionalDirective(directive))
             {
                 // #if/#elif/#else/#endif directive cases.
                 var matchingDirectives = GetMatchingConditionalDirectives(directive, cancellationToken);
-                matchingDirective = matchingDirectives[(matchingDirectives.IndexOf(directive) + 1) % matchingDirectives.Count];
+                if (matchingDirectives?.Count > 0)
+                {
+                    matchingDirective = matchingDirectives[(matchingDirectives.IndexOf(directive) + 1) % matchingDirectives.Count];
+                }
             }
             else
             {

--- a/src/EditorFeatures/Test/BraceHighlighting/AbstractBraceHighlightingTests.cs
+++ b/src/EditorFeatures/Test/BraceHighlighting/AbstractBraceHighlightingTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.BraceHighlighting
                 var context = new TaggerContext<BraceHighlightTag>(
                     document, buffer.CurrentSnapshot,
                     new SnapshotPoint(buffer.CurrentSnapshot, testDocument.CursorPosition.Value));
-                provider.ProduceTagsAsync_ForTestingPurposesOnly(context).Wait();
+                await provider.ProduceTagsAsync_ForTestingPurposesOnly(context);
 
                 var expectedHighlights = testDocument.SelectedSpans.Select(ts => ts.ToSpan()).OrderBy(s => s.Start).ToList();
                 var actualHighlights = context.tagSpans.Select(ts => ts.Span.Span).OrderBy(s => s.Start).ToList();

--- a/src/EditorFeatures/Test/BraceMatching/AbstractBraceMatcherTests.cs
+++ b/src/EditorFeatures/Test/BraceMatching/AbstractBraceMatcherTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.BraceMatching
                 var document = GetDocument(workspace);
                 var braceMatcher = workspace.GetService<IBraceMatchingService>();
 
-                var foundSpan = braceMatcher.FindMatchingSpanAsync(document, position, CancellationToken.None).Result;
+                var foundSpan = await braceMatcher.FindMatchingSpanAsync(document, position, CancellationToken.None);
 
                 string parsedExpectedCode;
                 IList<TextSpan> expectedSpans;

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             using (var context = await TestContext.CreateAsync(initial, expected, compareTokens))
             {
                 var @namespace = CodeGenerationSymbolFactory.CreateNamespaceSymbol(name, imports, members);
-                context.Result = context.Service.AddNamespaceAsync(context.Solution, (INamespaceSymbol)context.GetDestination(), @namespace, codeGenerationOptions).Result;
+                context.Result = await context.Service.AddNamespaceAsync(context.Solution, (INamespaceSymbol)context.GetDestination(), @namespace, codeGenerationOptions);
             }
         }
 
@@ -68,11 +68,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     constantValue);
                 if (!addToCompilationUnit)
                 {
-                    context.Result = context.Service.AddFieldAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), field, codeGenerationOptions).Result;
+                    context.Result = await context.Service.AddFieldAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), field, codeGenerationOptions);
                 }
                 else
                 {
-                    var newRoot = context.Service.AddField(context.Document.GetSyntaxRootAsync().Result, field, codeGenerationOptions);
+                    var newRoot = context.Service.AddField(await context.Document.GetSyntaxRootAsync(), field, codeGenerationOptions);
                     context.Result = context.Document.WithSyntaxRoot(newRoot);
                 }
             }
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     statements,
                     baseConstructorArguments: baseArguments,
                     thisConstructorArguments: thisArguments);
-                context.Result = context.Service.AddMethodAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), ctor, codeGenerationOptions).Result;
+                context.Result = await context.Service.AddMethodAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), ctor, codeGenerationOptions);
             }
         }
 
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     parameterSymbols,
                     parsedStatements,
                     handlesExpressions: handlesExpressions);
-                context.Result = context.Service.AddMethodAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), method, codeGenerationOptions).Result;
+                context.Result = await context.Service.AddMethodAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), method, codeGenerationOptions);
             }
         }
 
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     parameterSymbols,
                     parsedStatements));
 
-                context.Result = context.Service.AddMembersAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), methods.ToArray(), codeGenerationOptions).Result;
+                context.Result = await context.Service.AddMembersAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), methods.ToArray(), codeGenerationOptions);
             }
         }
 
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     isImplicit,
                     parsedStatements);
 
-                context.Result = context.Service.AddMethodAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), method, codeGenerationOptions).Result;
+                context.Result = await context.Service.AddMethodAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), method, codeGenerationOptions);
             }
         }
 
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var parsedStatements = context.ParseStatements(statements);
                 var oldSyntax = context.GetSelectedSyntax<SyntaxNode>(true);
                 var newSyntax = context.Service.AddStatements(oldSyntax, parsedStatements, codeGenerationOptions);
-                context.Result = context.Document.WithSyntaxRoot(context.Document.GetSyntaxRootAsync().Result.ReplaceNode(oldSyntax, newSyntax));
+                context.Result = context.Document.WithSyntaxRoot((await context.Document.GetSyntaxRootAsync()).ReplaceNode(oldSyntax, newSyntax));
             }
         }
 
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var parameterSymbols = GetParameterSymbols(parameters, context);
                 var oldMemberSyntax = context.GetSelectedSyntax<SyntaxNode>(true);
                 var newMemberSyntax = context.Service.AddParameters(oldMemberSyntax, parameterSymbols, codeGenerationOptions);
-                context.Result = context.Document.WithSyntaxRoot(context.Document.GetSyntaxRootAsync().Result.ReplaceNode(oldMemberSyntax, newMemberSyntax));
+                context.Result = context.Document.WithSyntaxRoot((await context.Document.GetSyntaxRootAsync()).ReplaceNode(oldMemberSyntax, newMemberSyntax));
             }
         }
 
@@ -319,7 +319,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     name,
                     typeParameters,
                     parameterSymbols);
-                context.Result = context.Service.AddNamedTypeAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), type, codeGenerationOptions).Result;
+                context.Result = await context.Service.AddNamedTypeAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), type, codeGenerationOptions);
             }
         }
 
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     addMethod,
                     removeMethod,
                     raiseMethod);
-                context.Result = context.Service.AddEventAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), @event, codeGenerationOptions).Result;
+                context.Result = await context.Service.AddEventAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), @event, codeGenerationOptions);
             }
         }
 
@@ -435,7 +435,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     getAccessor,
                     setAccessor,
                     isIndexer);
-                context.Result = context.Service.AddPropertyAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), property, codeGenerationOptions).Result;
+                context.Result = await context.Service.AddPropertyAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), property, codeGenerationOptions);
             }
         }
 
@@ -458,7 +458,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             {
                 var memberSymbols = GetSymbols(members, context);
                 var type = CodeGenerationSymbolFactory.CreateNamedTypeSymbol(null, accessibility, modifiers, typeKind, name, typeParameters, baseType, interfaces, specialType, memberSymbols);
-                context.Result = context.Service.AddNamedTypeAsync(context.Solution, (INamespaceSymbol)context.GetDestination(), type, codeGenerationOptions).Result;
+                context.Result = await context.Service.AddNamedTypeAsync(context.Solution, (INamespaceSymbol)context.GetDestination(), type, codeGenerationOptions);
             }
         }
 
@@ -569,22 +569,22 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var projectId = ProjectId.CreateNewId();
                 var documentId = DocumentId.CreateNewId(projectId);
 
-                var semanticModel = context.Solution
+                var semanticModel = await context.Solution
                     .AddProject(projectId, "GenerationSource", "GenerationSource", TestContext.GetLanguage(symbolSource))
                     .AddDocument(documentId, "Source.cs", symbolSource)
                     .GetDocument(documentId)
-                    .GetSemanticModelAsync().Result;
+                    .GetSemanticModelAsync();
 
                 var symbol = context.GetSelectedSymbol<INamespaceOrTypeSymbol>(destSpan, semanticModel);
                 var destination = context.GetDestination();
                 if (destination.IsType)
                 {
                     var members = onlyGenerateMembers ? symbol.GetMembers().ToArray() : new[] { symbol };
-                    context.Result = context.Service.AddMembersAsync(context.Solution, (INamedTypeSymbol)destination, members, codeGenerationOptions).Result;
+                    context.Result = await context.Service.AddMembersAsync(context.Solution, (INamedTypeSymbol)destination, members, codeGenerationOptions);
                 }
                 else
                 {
-                    context.Result = context.Service.AddNamespaceOrTypeAsync(context.Solution, (INamespaceSymbol)destination, symbol, codeGenerationOptions).Result;
+                    context.Result = await context.Service.AddNamespaceOrTypeAsync(context.Solution, (INamespaceSymbol)destination, symbol, codeGenerationOptions);
                 }
             }
         }

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -213,11 +213,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 ArgumentException exception = null;
                 try
                 {
-                    context.Service.AddMethodAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), method, codeGenerationOptions).Wait();
+                    await context.Service.AddMethodAsync(context.Solution, (INamedTypeSymbol)context.GetDestination(), method, codeGenerationOptions);
                 }
-                catch (AggregateException e)
+                catch (ArgumentException e)
                 {
-                    exception = e.InnerException as ArgumentException;
+                    exception = e;
                 }
 
                 var expectedMessage = string.Format(WorkspacesResources.CannotCodeGenUnsupportedOperator, method.Name);

--- a/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
+++ b/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
                 var project = workspace.CurrentSolution.Projects.Single();
                 var document = project.Documents.Single();
                 var extensionManager = document.Project.Solution.Workspace.Services.GetService<IExtensionManager>() as EditorLayerExtensionManager.ExtensionManager;
-                var result = refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), CancellationToken.None).Result;
+                var result = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), CancellationToken.None);
                 Assert.True(extensionManager.IsDisabled(codeRefactoring));
                 Assert.False(extensionManager.IsIgnored(codeRefactoring));
             }

--- a/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private async Task CheckResultsAsync(Document document, int position, string expectedItemOrNull, string expectedDescriptionOrNull, bool usePreviousCharAsTrigger, bool checkForAbsence, Glyph? glyph)
         {
-            var code = document.GetTextAsync().Result.ToString();
+            var code = (await document.GetTextAsync()).ToString();
 
             CompletionTriggerInfo triggerInfo = new CompletionTriggerInfo();
 
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             var completionRules = GetCompletionRules(document);
             var commitChar = commitCharOpt ?? '\t';
 
-            var text = document.GetTextAsync().Result;
+            var text = await document.GetTextAsync();
 
             if (commitChar == '\t' || completionRules.IsCommitCharacter(firstItem, commitChar, textTypedSoFar))
             {
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                     AssertEx.Any(completionList.Items, c => CompareItems(c.DisplayText, expectedItem));
 
                     // Throw if multiple to indicate a bad test case
-                    var description = completionList.Items.Single(c => CompareItems(c.DisplayText, expectedItem)).GetDescriptionAsync().Result;
+                    var description = await completionList.Items.Single(c => CompareItems(c.DisplayText, expectedItem)).GetDescriptionAsync();
 
                     if (expectedSymbols == 1)
                     {
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 var triggerInfo = new CompletionTriggerInfo();
                 var completionList = await GetCompletionListAsync(document, position, triggerInfo);
                 var item = completionList.Items.FirstOrDefault(i => i.DisplayText == expectedItem);
-                Assert.Equal(expectedDescription, item.GetDescriptionAsync().Result.GetFullText());
+                Assert.Equal(expectedDescription, (await item.GetDescriptionAsync()).GetFullText());
             }
         }
 
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 Assert.NotNull(item);
                 if (expectedDescription != null)
                 {
-                    var actualDescription = item.GetDescriptionAsync().Result.GetFullText();
+                    var actualDescription = (await item.GetDescriptionAsync()).GetFullText();
                     Assert.Equal(expectedDescription, actualDescription);
                 }
             }

--- a/src/EditorFeatures/Test/Extensions/ISemanticSnapshotExtensionTests.cs
+++ b/src/EditorFeatures/Test/Extensions/ISemanticSnapshotExtensionTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
                 var document = workspace.CurrentSolution.GetDocument(workspace.Documents.Single().Id);
                 Assert.NotNull(document);
 
-                var symbol = SymbolFinder.FindSymbolAtPositionAsync(document, position, cancellationToken: CancellationToken.None).Result;
+                var symbol = await SymbolFinder.FindSymbolAtPositionAsync(document, position);
                 Assert.Null(symbol);
             }
         }

--- a/src/EditorFeatures/Test/ExtractInterface/AbstractExtractInterfaceTests.cs
+++ b/src/EditorFeatures/Test/ExtractInterface/AbstractExtractInterfaceTests.cs
@@ -102,14 +102,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface
                     if (expectedUpdatedOriginalDocumentCode != null)
                     {
                         var updatedOriginalDocument = result.UpdatedSolution.GetDocument(testState.ExtractFromDocument.Id);
-                        var updatedCode = updatedOriginalDocument.GetTextAsync().Result.ToString();
+                        var updatedCode = (await updatedOriginalDocument.GetTextAsync()).ToString();
                         Assert.Equal(expectedUpdatedOriginalDocumentCode, updatedCode);
                     }
 
                     if (expectedInterfaceCode != null)
                     {
                         var interfaceDocument = result.UpdatedSolution.GetDocument(result.NavigationDocumentId);
-                        var interfaceCode = interfaceDocument.GetTextAsync().Result.ToString();
+                        var interfaceCode = (await interfaceDocument.GetTextAsync()).ToString();
                         Assert.Equal(expectedInterfaceCode, interfaceCode);
                     }
                 }

--- a/src/EditorFeatures/Test/KeywordHighlighting/AbstractKeywordHighlighterTests.cs
+++ b/src/EditorFeatures/Test/KeywordHighlighting/AbstractKeywordHighlighterTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.KeywordHighlighting
                 // ancestor node.
                 var highlighter = CreateHighlighter();
 
-                var root = document.GetSyntaxRootAsync().Result;
+                var root = await document.GetSyntaxRootAsync();
 
                 for (int i = 0; i <= cursorSpan.Length; i++)
                 {

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                 {
                     var newDoc = metadataProject.AddDocument("MetadataSource", source);
                     metadataProject = newDoc.Project;
-                    references.Add(MetadataReference.CreateFromImage(metadataProject.GetCompilationAsync().Result.EmitToArray()));
+                    references.Add(MetadataReference.CreateFromImage((await metadataProject.GetCompilationAsync()).EmitToArray()));
                     metadataProject = metadataProject.RemoveDocument(newDoc.Id);
                 }
 
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                 var metadataSymbolId = metadataSymbol.GetSymbolKey();
                 var generatedFile = context.GenerateSource(symbolName);
                 var generatedDocument = context.GetDocument(generatedFile);
-                var generatedCompilation = generatedDocument.Project.GetCompilationAsync().Result;
+                var generatedCompilation = await generatedDocument.Project.GetCompilationAsync();
                 var generatedSymbol = generatedCompilation.Assembly.GetTypeByMetadataName(symbolName);
                 Assert.False(generatedSymbol.Locations.Where(loc => loc.IsInSource).IsEmpty());
                 Assert.True(SymbolKey.GetComparer(ignoreCase: true, ignoreAssemblyKeys: false).Equals(metadataSymbolId, generatedSymbol.GetSymbolKey()));

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -745,7 +745,7 @@ End Class");
             {
                 var file = context.GenerateSource("System.Console", project: context.DefaultProject);
                 var document = context.GetDocument(file);
-                Microsoft.CodeAnalysis.Formatting.Formatter.FormatAsync(document).Wait();
+                await Formatting.Formatter.FormatAsync(document);
             }
         }
 

--- a/src/EditorFeatures/Test/Outlining/OutliningTaggerTests.cs
+++ b/src/EditorFeatures/Test/Outlining/OutliningTaggerTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
 
             using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
             {
-                var tags = GetTagsFromWorkspace(workspace);
+                var tags = await GetTagsFromWorkspaceAsync(workspace);
 
                 // ensure all 4 outlining region tags were found
                 Assert.Equal(4, tags.Count);
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
 
             using (var workspace = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
             {
-                var tags = GetTagsFromWorkspace(workspace);
+                var tags = await GetTagsFromWorkspaceAsync(workspace);
 
                 // ensure all 4 outlining region tags were found
                 Assert.Equal(4, tags.Count);
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
 
             using (var workspace = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
             {
-                var tags = GetTagsFromWorkspace(workspace);
+                var tags = await GetTagsFromWorkspaceAsync(workspace);
 
                 var hints = tags.Select(x => x.CollapsedHintForm).Cast<ViewHostingControl>().ToArray();
                 Assert.Equal("Sub Main(args As String())\r\nEnd Sub", hints[1].ToString()); // method
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
             }
         }
 
-        private static List<IOutliningRegionTag> GetTagsFromWorkspace(TestWorkspace workspace)
+        private static async Task<List<IOutliningRegionTag>> GetTagsFromWorkspaceAsync(TestWorkspace workspace)
         {
             var hostdoc = workspace.Documents.First();
             var view = hostdoc.GetTextView();
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
 
             var document = workspace.CurrentSolution.GetDocument(hostdoc.Id);
             var context = new TaggerContext<IOutliningRegionTag>(document, view.TextSnapshot);
-            provider.ProduceTagsAsync_ForTestingPurposesOnly(context).Wait();
+            await provider.ProduceTagsAsync_ForTestingPurposesOnly(context);
 
             return context.tagSpans.Select(x => x.Tag).ToList();
         }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
 
             var actions = new List<CodeAction>();
             var context = new CodeFixContext(document, diagnostics[0], (a, d) => actions.Add(a), CancellationToken.None);
-            _codeFixProvider.RegisterCodeFixesAsync(context).Wait();
+            await _codeFixProvider.RegisterCodeFixesAsync(context);
 
             // There should only be one code action
             Assert.Equal(1, actions.Count);

--- a/src/EditorFeatures/Test2/Diagnostics/AbstractCrossLanguageUserDiagnosticTest.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/AbstractCrossLanguageUserDiagnosticTest.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(definition)
                 Dim diagnosticAndFix = Await GetDiagnosticAndFixAsync(workspace)
                 Dim codeAction = diagnosticAndFix.Item2.Fixes.ElementAt(codeActionIndex).Action
-                Dim operations = codeAction.GetOperationsAsync(CancellationToken.None).Result
+                Dim operations = Await codeAction.GetOperationsAsync(CancellationToken.None)
                 Dim edit = operations.OfType(Of ApplyChangesOperation)().First()
 
                 Dim oldSolution = workspace.CurrentSolution
@@ -87,7 +87,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
             Dim ids = New HashSet(Of String)(fixer.FixableDiagnosticIds)
             Dim diagnostics = docAndDiagnostics.Item2.Where(Function(d) ids.Contains(d.Id)).ToList()
-            Dim tree = _document.GetSyntaxTreeAsync().Result
+            Dim tree = Await _document.GetSyntaxTreeAsync()
 
             For Each diagnostic In diagnostics
                 Dim fixes = New List(Of CodeFix)
@@ -110,7 +110,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
 
             Dim syntaxFacts = document.Project.LanguageServices.GetService(Of ISyntaxFactsService)()
-            Dim root = document.GetSyntaxRootAsync().Result
+            Dim root = Await document.GetSyntaxRootAsync()
             Dim start = syntaxFacts.GetContainingMemberDeclaration(root, invocationPoint)
 
             Dim result = Await DiagnosticProviderTestUtilities.GetAllDiagnosticsAsync(provider, document, start.FullSpan)
@@ -128,7 +128,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(xmlDefinition)
                 Dim diagnosticAndFix = Await GetDiagnosticAndFixAsync(workspace)
                 Dim codeAction = diagnosticAndFix.Item2.Fixes.ElementAt(index).Action
-                Dim operations = codeAction.GetOperationsAsync(CancellationToken.None).Result
+                Dim operations = Await codeAction.GetOperationsAsync(CancellationToken.None)
                 Dim edit = operations.OfType(Of ApplyChangesOperation)().First()
                 Dim addedProjectReference = SolutionUtilities.GetSingleAddedProjectReference(workspace.CurrentSolution, edit.ChangedSolution)
 
@@ -147,7 +147,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(xmlDefinition)
                 Dim diagnosticAndFix = Await GetDiagnosticAndFixAsync(workspace)
                 Dim codeAction = diagnosticAndFix.Item2.Fixes.ElementAt(index).Action
-                Dim operations = codeAction.GetOperationsAsync(CancellationToken.None).Result
+                Dim operations = Await codeAction.GetOperationsAsync(CancellationToken.None)
 
                 Dim edit = operations.OfType(Of ApplyChangesOperation)().FirstOrDefault()
                 Assert.Equal(Nothing, edit)
@@ -159,10 +159,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             End Using
         End Function
 
-
         Protected Overridable Function GetNode(doc As Document, position As Integer) As SyntaxNode
             Return doc.GetSyntaxRootAsync().Result.FindToken(position).Parent
         End Function
-
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/KeywordHighlighting/AbstractKeywordHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/KeywordHighlighting/AbstractKeywordHighlightingTests.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.KeywordHighlighting
                     AggregateAsynchronousOperationListener.EmptyListeners)
 
                 Dim context = New TaggerContext(Of KeywordHighlightTag)(document, snapshot, New SnapshotPoint(snapshot, caretPosition))
-                tagProducer.ProduceTagsAsync_ForTestingPurposesOnly(context).Wait()
+                Await tagProducer.ProduceTagsAsync_ForTestingPurposesOnly(context)
 
                 Dim producedTags = From tag In context.tagSpans
                                    Order By tag.Span.Start

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                 Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
                 Dim context = New TaggerContext(Of NavigableHighlightTag)(
                     document, snapshot, New SnapshotPoint(snapshot, caretPosition))
-                tagProducer.ProduceTagsAsync_ForTestingPurposesOnly(context).Wait()
+                Await tagProducer.ProduceTagsAsync_ForTestingPurposesOnly(context)
 
                 Dim producedTags = From tag In context.tagSpans
                                    Order By tag.Span.Start

--- a/src/EditorFeatures/Test2/Workspaces/SymbolDescriptionServiceTests.vb
+++ b/src/EditorFeatures/Test2/Workspaces/SymbolDescriptionServiceTests.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             ' For String Literals GetTouchingWord returns Nothing, we still need this for Quick Info. Quick Info code does exactly the following.
             ' caveat: The comment above the previous line of code. Do not put the cursor at the end of the token.
             If commonSyntaxToken = Nothing Then
-                commonSyntaxToken = (Await document.GetSyntaxTreeAsync()).GetRoot().FindToken(cursorPosition)
+                commonSyntaxToken = (Await document.GetSyntaxRootAsync()).FindToken(cursorPosition)
             End If
 
             Dim semanticModel = Await document.GetSemanticModelAsync()

--- a/src/EditorFeatures/VisualBasic/BraceMatching/VisualBasicDirectiveTriviaBraceMatcher.vb
+++ b/src/EditorFeatures/VisualBasic/BraceMatching/VisualBasicDirectiveTriviaBraceMatcher.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.BraceMatching
              RegionDirectiveTriviaSyntax, EndRegionDirectiveTriviaSyntax)
 
         Friend Overrides Function GetMatchingConditionalDirectives(directive As DirectiveTriviaSyntax, cancellationToken As CancellationToken) As List(Of DirectiveTriviaSyntax)
-            Return directive.GetMatchingConditionalDirectives(cancellationToken).ToList()
+            Return directive.GetMatchingConditionalDirectives(cancellationToken)?.ToList()
         End Function
 
         Friend Overrides Function GetMatchingDirective(directive As DirectiveTriviaSyntax, cancellationToken As CancellationToken) As DirectiveTriviaSyntax

--- a/src/EditorFeatures/VisualBasicTest/BraceMatching/BraceHighlightingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/BraceMatching/BraceHighlightingTests.vb
@@ -24,8 +24,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
             Return array
         End Function
 
-        Private Function ProduceTags(workspace As TestWorkspace, buffer As ITextBuffer, position As Integer) As IEnumerable(Of ITagSpan(Of BraceHighlightTag))
-            WpfTestCase.RequireWpfFact($"{NameOf(BraceHighlightingTests)}.{NameOf(ProduceTags)} creates asynchronous taggers")
+        Private Async Function ProduceTagsAsync(workspace As TestWorkspace, buffer As ITextBuffer, position As Integer) As Tasks.Task(Of IEnumerable(Of ITagSpan(Of BraceHighlightTag)))
+            WpfTestCase.RequireWpfFact($"{NameOf(BraceHighlightingTests)}.{"ProduceTagsAsync"} creates asynchronous taggers")
 
             Dim producer = New BraceHighlightingViewTaggerProvider(
                 workspace.GetService(Of IBraceMatchingService),
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
             Dim doc = buffer.CurrentSnapshot.GetRelatedDocumentsWithChanges().FirstOrDefault()
             Dim context = New TaggerContext(Of BraceHighlightTag)(
                 doc, buffer.CurrentSnapshot, New SnapshotPoint(buffer.CurrentSnapshot, position))
-            producer.ProduceTagsAsync_ForTestingPurposesOnly(context).Wait()
+            Await producer.ProduceTagsAsync_ForTestingPurposesOnly(context)
             Return context.tagSpans
         End Function
 
@@ -48,27 +48,27 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
                 Dim buffer = workspace.Documents.First().GetTextBuffer()
 
                 ' Before open parens
-                Dim result = ProduceTags(workspace, buffer, 31)
+                Dim result = Await ProduceTagsAsync(workspace, buffer, 31)
                 Assert.True(result.IsEmpty())
 
                 ' At open parens
-                result = ProduceTags(workspace, buffer, 32)
+                result = Await ProduceTagsAsync(workspace, buffer, 32)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(32, 33), Span.FromBounds(45, 46))))
 
                 ' After open parens
-                result = ProduceTags(workspace, buffer, 33)
+                result = Await ProduceTagsAsync(workspace, buffer, 33)
                 Assert.True(result.IsEmpty())
 
                 ' Before close parens
-                result = ProduceTags(workspace, buffer, 44)
+                result = Await ProduceTagsAsync(workspace, buffer, 44)
                 Assert.True(result.IsEmpty())
 
                 ' At close parens
-                result = ProduceTags(workspace, buffer, 45)
+                result = Await ProduceTagsAsync(workspace, buffer, 45)
                 Assert.True(result.IsEmpty())
 
                 ' After close parens
-                result = ProduceTags(workspace, buffer, 46)
+                result = Await ProduceTagsAsync(workspace, buffer, 46)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(32, 33), Span.FromBounds(45, 46))))
             End Using
         End Function
@@ -87,64 +87,64 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
                 ' pos 0 on second line is 16
 
                 ' Before <
-                Dim result = ProduceTags(workspace, buffer, 19)
+                Dim result = Await ProduceTagsAsync(workspace, buffer, 19)
                 Assert.True(result.IsEmpty)
 
                 ' On <
-                result = ProduceTags(workspace, buffer, 20)
+                result = Await ProduceTagsAsync(workspace, buffer, 20)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(20, 21), Span.FromBounds(56, 57))))
 
                 ' After <
-                result = ProduceTags(workspace, buffer, 21)
+                result = Await ProduceTagsAsync(workspace, buffer, 21)
                 Assert.True(result.IsEmpty)
 
                 ' Before (
-                result = ProduceTags(workspace, buffer, 28)
+                result = Await ProduceTagsAsync(workspace, buffer, 28)
                 Assert.True(result.IsEmpty)
 
                 ' On (
-                result = ProduceTags(workspace, buffer, 29)
+                result = Await ProduceTagsAsync(workspace, buffer, 29)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(29, 30), Span.FromBounds(55, 56))))
 
                 ' After (
-                result = ProduceTags(workspace, buffer, 30)
+                result = Await ProduceTagsAsync(workspace, buffer, 30)
                 Assert.True(result.IsEmpty)
 
                 ' Before {
-                result = ProduceTags(workspace, buffer, 38)
+                result = Await ProduceTagsAsync(workspace, buffer, 38)
                 Assert.True(result.IsEmpty)
 
                 ' On {
-                result = ProduceTags(workspace, buffer, 39)
+                result = Await ProduceTagsAsync(workspace, buffer, 39)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(39, 40), Span.FromBounds(54, 55))))
 
                 ' After {
-                result = ProduceTags(workspace, buffer, 40)
+                result = Await ProduceTagsAsync(workspace, buffer, 40)
                 Assert.True(result.IsEmpty)
 
                 ' x is any character, | is the cursor in the following comments 
                 '|"})>
-                result = ProduceTags(workspace, buffer, 53)
+                result = Await ProduceTagsAsync(workspace, buffer, 53)
                 Assert.True(result.IsEmpty)
 
                 ' "|})>
-                result = ProduceTags(workspace, buffer, 54)
+                result = Await ProduceTagsAsync(workspace, buffer, 54)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(48, 49), Span.FromBounds(53, 54))))
 
                 ' }|)>
-                result = ProduceTags(workspace, buffer, 55)
+                result = Await ProduceTagsAsync(workspace, buffer, 55)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(39, 40), Span.FromBounds(54, 55))))
 
                 ' })|>
-                result = ProduceTags(workspace, buffer, 56)
+                result = Await ProduceTagsAsync(workspace, buffer, 56)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(29, 30), Span.FromBounds(55, 56))))
 
                 ' })>|
-                result = ProduceTags(workspace, buffer, 57)
+                result = Await ProduceTagsAsync(workspace, buffer, 57)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(20, 21), Span.FromBounds(56, 57))))
 
                 ' })>x|
-                result = ProduceTags(workspace, buffer, 58)
+                result = Await ProduceTagsAsync(workspace, buffer, 58)
                 Assert.True(result.IsEmpty)
             End Using
         End Function
@@ -158,32 +158,32 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
 
                 ' x is any character, | is the cursor in the following comments
                 ' |x()()
-                Dim result = ProduceTags(workspace, buffer, 26)
+                Dim result = Await ProduceTagsAsync(workspace, buffer, 26)
                 Assert.True(result.IsEmpty)
 
                 ' |()()
-                result = ProduceTags(workspace, buffer, 27)
+                result = Await ProduceTagsAsync(workspace, buffer, 27)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(27, 28), Span.FromBounds(28, 29))))
 
                 ' (|)()
-                result = ProduceTags(workspace, buffer, 28)
+                result = Await ProduceTagsAsync(workspace, buffer, 28)
                 Assert.True(result.IsEmpty)
 
                 ' ()|()
-                result = ProduceTags(workspace, buffer, 29)
+                result = Await ProduceTagsAsync(workspace, buffer, 29)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(27, 28), Span.FromBounds(28, 29),
                                                                                           Span.FromBounds(29, 30), Span.FromBounds(30, 31))))
 
                 ' ()(|)
-                result = ProduceTags(workspace, buffer, 30)
+                result = Await ProduceTagsAsync(workspace, buffer, 30)
                 Assert.True(result.IsEmpty)
 
                 ' ()()|
-                result = ProduceTags(workspace, buffer, 31)
+                result = Await ProduceTagsAsync(workspace, buffer, 31)
                 Assert.True(result.Select(Function(ts) ts.Span.Span).SetEquals(Enumerable(Span.FromBounds(29, 30), Span.FromBounds(30, 31))))
 
                 ' ()()x|
-                result = ProduceTags(workspace, buffer, 32)
+                result = Await ProduceTagsAsync(workspace, buffer, 32)
                 Assert.True(result.IsEmpty)
             End Using
         End Function
@@ -205,51 +205,51 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
                 Dim line6start = buffer.CurrentSnapshot.GetLineFromLineNumber(5).Start.Position
 
                 ' 2| > 3
-                Dim result = ProduceTags(workspace, buffer, 15 + line4start)
+                Dim result = Await ProduceTagsAsync(workspace, buffer, 15 + line4start)
                 Assert.True(result.IsEmpty)
 
                 ' 2 |> 3
-                result = ProduceTags(workspace, buffer, 16 + line4start)
+                result = Await ProduceTagsAsync(workspace, buffer, 16 + line4start)
                 Assert.True(result.IsEmpty)
 
                 ' 2 >| 3
-                result = ProduceTags(workspace, buffer, 17 + line4start)
+                result = Await ProduceTagsAsync(workspace, buffer, 17 + line4start)
                 Assert.True(result.IsEmpty)
 
                 ' 2 > |3
-                result = ProduceTags(workspace, buffer, 18 + line4start)
+                result = Await ProduceTagsAsync(workspace, buffer, 18 + line4start)
                 Assert.True(result.IsEmpty)
 
                 ' 4| > 5
-                result = ProduceTags(workspace, buffer, 15 + line5start)
+                result = Await ProduceTagsAsync(workspace, buffer, 15 + line5start)
                 Assert.True(result.IsEmpty)
 
                 ' 4 |> 5
-                result = ProduceTags(workspace, buffer, 16 + line5start)
+                result = Await ProduceTagsAsync(workspace, buffer, 16 + line5start)
                 Assert.True(result.IsEmpty)
 
                 ' 4 >| 5
-                result = ProduceTags(workspace, buffer, 17 + line5start)
+                result = Await ProduceTagsAsync(workspace, buffer, 17 + line5start)
                 Assert.True(result.IsEmpty)
 
                 ' 4 > |5
-                result = ProduceTags(workspace, buffer, 18 + line5start)
+                result = Await ProduceTagsAsync(workspace, buffer, 18 + line5start)
                 Assert.True(result.IsEmpty)
 
                 ' |<element> </element>
-                result = ProduceTags(workspace, buffer, 16 + line6start)
+                result = Await ProduceTagsAsync(workspace, buffer, 16 + line6start)
                 Assert.True(result.IsEmpty)
 
                 ' <element>| </element>
-                result = ProduceTags(workspace, buffer, 25 + line6start)
+                result = Await ProduceTagsAsync(workspace, buffer, 25 + line6start)
                 Assert.True(result.IsEmpty)
 
                 ' <element> |</element>
-                result = ProduceTags(workspace, buffer, 26 + line6start)
+                result = Await ProduceTagsAsync(workspace, buffer, 26 + line6start)
                 Assert.True(result.IsEmpty)
 
                 ' <element> </element>|
-                result = ProduceTags(workspace, buffer, 36 + line6start)
+                result = Await ProduceTagsAsync(workspace, buffer, 36 + line6start)
                 Assert.True(result.IsEmpty)
             End Using
         End Function

--- a/src/EditorFeatures/VisualBasicTest/BraceMatching/VisualBasicBraceMatcherTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/BraceMatching/VisualBasicBraceMatcherTests.vb
@@ -590,5 +590,74 @@ End Class
             Await TestAsync(code, expected)
         End Function
 
+        <WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)>
+        Public Async Function TestUnmatchedIncompleteConditionalDirective() As Task
+            Dim code =
+<Text>
+Class C
+    Sub Test()
+#If$$
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+            Dim expected =
+<Text>
+Class C
+    Sub Test()
+[|#If|]
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+
+            Await TestAsync(code, expected)
+        End Function
+
+        <WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)>
+        Public Async Function TestUnmatchedCompleteConditionalDirective() As Task
+            Dim code =
+<Text>
+Class C
+    Sub Test()
+#If$$ CHK Then
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+            Dim expected =
+<Text>
+Class C
+    Sub Test()
+[|#If|] CHK Then
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+
+            Await TestAsync(code, expected)
+        End Function
+
+        <WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)>
+        Public Async Function TestUnmatchedConditionalDirective() As Task
+            Dim code =
+<Text>
+Class C
+    Sub Test()
+#Else$$
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+            Dim expected =
+<Text>
+Class C
+    Sub Test()
+[|#Else|]
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+
+            Await TestAsync(code, expected)
+        End Function
+
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/CaseCorrecting/CaseCorrectionServiceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CaseCorrecting/CaseCorrectionServiceTests.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CaseCorrecting
             Dim hostDocument = workspace.Documents.First()
             Dim buffer = hostDocument.GetTextBuffer()
             Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
-            Dim span = (Await document.GetSyntaxTreeAsync(CancellationToken.None)).GetRoot(CancellationToken.None).FullSpan
+            Dim span = (Await document.GetSyntaxRootAsync()).FullSpan
 
             Dim newDocument = Await CaseCorrector.CaseCorrectAsync(document, span, CancellationToken.None)
             newDocument.Project.Solution.Workspace.ApplyDocumentChanges(newDocument, CancellationToken.None)

--- a/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
@@ -24,10 +24,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
                 Dim classifiers = service.GetDefaultSyntaxClassifiers()
                 Dim extensionManager = workspace.Services.GetService(Of IExtensionManager)
 
-                service.AddSemanticClassificationsAsync(document, textSpan,
+                Await service.AddSemanticClassificationsAsync(document, textSpan,
                     extensionManager.CreateNodeExtensionGetter(classifiers, Function(c) c.SyntaxNodeTypes),
                     extensionManager.CreateTokenExtensionGetter(classifiers, Function(c) c.SyntaxTokenKinds),
-                    result, CancellationToken.None).Wait()
+                    result, CancellationToken.None)
 
                 Return result
             End Using

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
                 Dim document = workspace.CurrentSolution.GetDocument(documentId)
                 Dim position = hostDocument.CursorPosition.Value
 
-                Dim completionList = GetCompletionList(document, position, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo())
+                Dim completionList = Await GetCompletionListAsync(document, position, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo())
                 Dim item = completionList.Items.First(Function(i) i.DisplayText.StartsWith(textTypedSoFar))
 
                 Dim completionService = document.Project.LanguageServices.GetService(Of ICompletionService)()
@@ -133,7 +133,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
                 Dim document = workspace.CurrentSolution.GetDocument(documentId)
                 Dim position = hostDocument.CursorPosition.Value
 
-                Dim completionList = GetCompletionList(document, position, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo())
+                Dim completionList = Await GetCompletionListAsync(document, position, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo())
                 Dim item = completionList.Items.First()
 
                 Dim completionService = document.Project.LanguageServices.GetService(Of ICompletionService)()

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
@@ -432,7 +432,7 @@ End Class]]></a>.Value.NormalizeLineEndings()
                 Dim provider = New CrefCompletionProvider()
                 Dim hostDocument = workspace.DocumentWithCursor
                 Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
-                Dim completionList = GetCompletionList(provider, document, hostDocument.CursorPosition.Value, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo())
+                Dim completionList = Await GetCompletionListAsync(provider, document, hostDocument.CursorPosition.Value, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo())
             End Using
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
@@ -645,7 +645,7 @@ End Interface
                 Dim document = testWorkspace.CurrentSolution.GetDocument(testWorkspace.Documents.Single().Id)
                 Dim triggerInfo = New CompletionTriggerInfo()
 
-                Dim completionList = GetCompletionList(document, position, triggerInfo)
+                Dim completionList = Await GetCompletionListAsync(document, position, triggerInfo)
                 AssertEx.Any(completionList.Items, Function(c) c.DisplayText = "Workcover")
 
             End Using

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
@@ -408,7 +408,7 @@ End Program</Document>
                 Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
                 Dim triggerInfo = CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo()
 
-                Dim completionList = GetCompletionList(document, caretPosition, triggerInfo)
+                Dim completionList = Await GetCompletionListAsync(document, caretPosition, triggerInfo)
                 Assert.True(completionList Is Nothing OrElse completionList.IsExclusive, "Expected always exclusive")
             End Using
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
@@ -1752,7 +1752,7 @@ public class C
                 Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
                 Dim triggerInfo = CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo()
 
-                Dim completionList = GetCompletionList(document, caretPosition, triggerInfo)
+                Dim completionList = Await GetCompletionListAsync(document, caretPosition, triggerInfo)
                 Assert.False(completionList.Items.Any(Function(c) c.DisplayText = "e"))
             End Using
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
@@ -321,20 +321,20 @@ End Class
                                  (Await workspaceFixture.GetWorkspaceAsync()).Options)
 
                 Dim document1 = Await workspaceFixture.UpdateDocumentAsync(code, SourceCodeKind.Regular)
-                CheckResults(document1, position, isBuilder, triggerInfo, options)
+                Await CheckResultsAsync(document1, position, isBuilder, triggerInfo, options)
 
                 If CanUseSpeculativeSemanticModel(document1, position) Then
                     Dim document2 = Await workspaceFixture.UpdateDocumentAsync(code, SourceCodeKind.Regular, cleanBeforeUpdate:=False)
-                    CheckResults(document2, position, isBuilder, triggerInfo, options)
+                    Await CheckResultsAsync(document2, position, isBuilder, triggerInfo, options)
                 End If
             End Using
 
         End Function
 
-        Private Sub CheckResults(document As Document, position As Integer, isBuilder As Boolean, triggerInfo As CompletionTriggerInfo?, options As OptionSet)
+        Private Async Function CheckResultsAsync(document As Document, position As Integer, isBuilder As Boolean, triggerInfo As CompletionTriggerInfo?, options As OptionSet) As Task
             triggerInfo = If(triggerInfo, CompletionTriggerInfo.CreateTypeCharTriggerInfo("a"c))
 
-            Dim completionList = GetCompletionList(document, position, triggerInfo.Value, options)
+            Dim completionList = Await GetCompletionListAsync(document, position, triggerInfo.Value, options)
 
             If isBuilder Then
                 Assert.NotNull(completionList)
@@ -344,7 +344,7 @@ End Class
                     Assert.True(completionList.Builder Is Nothing, "group.Builder = " & If(completionList.Builder IsNot Nothing, completionList.Builder.DisplayText, "null"))
                 End If
             End If
-        End Sub
+        End Function
 
         Friend Overrides Function CreateCompletionProvider() As CompletionListProvider
             Return New VisualBasicSuggestionModeCompletionProvider()

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -161,8 +161,8 @@ End Class</text>
 
                 Dim sdocument = Await SemanticDocument.CreateAsync(document, CancellationToken.None)
 
-                Dim tree = Await document.GetSyntaxTreeAsync()
-                Dim iterator = tree.GetRoot().DescendantNodesAndSelf()
+                Dim root = Await document.GetSyntaxRootAsync()
+                Dim iterator = root.DescendantNodesAndSelf()
 
                 Dim options = document.Project.Solution.Workspace.Options _
                                       .WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, True)

--- a/src/EditorFeatures/VisualBasicTest/Formatting/FormattingTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/FormattingTestBase.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting
                 Dim rules = formattingRuleProvider.CreateRule(document, 0).Concat(Formatter.GetDefaultFormattingRules(document))
 
                 Dim changes = Formatter.GetFormattedTextChanges(
-                    syntaxTree.GetRoot(CancellationToken.None),
+                    Await syntaxTree.GetRootAsync(),
                     workspace.Documents.First(Function(d) d.SelectedSpans.Any()).SelectedSpans,
                     workspace, workspace.Options, rules, CancellationToken.None)
                 AssertResult(expected, clonedBuffer, changes)

--- a/src/EditorFeatures/VisualBasicTest/LineSeparators/LineSeparatorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineSeparators/LineSeparatorTests.vb
@@ -293,7 +293,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
             Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(lines)
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id)
                 Dim spans = Await New VisualBasicLineSeparatorService().GetLineSeparatorsAsync(document,
-                    (Await document.GetSyntaxTreeAsync()).GetRoot().FullSpan)
+                    (Await document.GetSyntaxRootAsync()).FullSpan)
                 Return spans.OrderBy(Function(span) span.Start)
             End Using
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Outlining/CommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Outlining/CommentTests.vb
@@ -16,18 +16,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
             End Get
         End Property
 
-        Friend Overrides Function GetRegionsAsync(document As Document, position As Integer) As Task(Of OutliningSpan())
-            Dim root = document.GetSyntaxRootAsync(CancellationToken.None).Result
+        Friend Overrides Async Function GetRegionsAsync(document As Document, position As Integer) As Task(Of OutliningSpan())
+            Dim root = Await document.GetSyntaxRootAsync()
             Dim trivia = root.FindTrivia(position, findInsideTrivia:=True)
 
             Dim token = trivia.Token
 
             If token.LeadingTrivia.Contains(trivia) Then
-                Return Task.FromResult(VisualBasicOutliningHelpers.CreateCommentsRegions(token.LeadingTrivia).ToArray())
+                Return CreateCommentsRegions(token.LeadingTrivia).ToArray()
             ElseIf token.TrailingTrivia.Contains(trivia) Then
-                Return Task.FromResult(VisualBasicOutliningHelpers.CreateCommentsRegions(token.TrailingTrivia).ToArray())
+                Return CreateCommentsRegions(token.TrailingTrivia).ToArray()
             Else
-                Return Task.FromResult(Contract.FailWithReturn(Of OutliningSpan())())
+                Return Contract.FailWithReturn(Of OutliningSpan())()
             End If
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/TodoComment/TodoCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TodoComment/TodoCommentTests.vb
@@ -185,7 +185,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TodoComment
 
                 Dim document = workspace.Documents.First()
                 Dim documentId = document.Id
-                worker.AnalyzeSyntaxAsync(workspace.CurrentSolution.GetDocument(documentId), CancellationToken.None).Wait()
+                Await worker.AnalyzeSyntaxAsync(workspace.CurrentSolution.GetDocument(documentId), CancellationToken.None)
 
                 Dim todoLists = worker.GetItems_TestingOnly(documentId)
 

--- a/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TypeInferrer
         End Sub
 
         Protected Overrides Async Function TestWorkerAsync(document As Document, textSpan As TextSpan, expectedType As String, useNodeStartPosition As Boolean) As Task
-            Dim root = (Await document.GetSyntaxTreeAsync()).GetRoot()
+            Dim root = Await document.GetSyntaxRootAsync()
             Dim node = FindExpressionSyntaxFromSpan(root, textSpan)
             Dim typeInference = document.GetLanguageService(Of ITypeInferenceService)()
 

--- a/src/Features/CSharp/Portable/CodeFixes/FullyQualify/CSharpFullyQualifyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/FullyQualify/CSharpFullyQualifyCodeFixProvider.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeFixes.FullyQualify;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -71,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FullyQualify
             return true;
         }
 
-        protected override SyntaxNode ReplaceNode(SyntaxNode node, string containerName, CancellationToken cancellationToken)
+        protected override async Task<SyntaxNode> ReplaceNodeAsync(SyntaxNode node, string containerName, CancellationToken cancellationToken)
         {
             var simpleName = (SimpleNameSyntax)node;
 
@@ -85,7 +86,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FullyQualify
             qualifiedName = qualifiedName.WithAdditionalAnnotations(Formatter.Annotation);
 
             var syntaxTree = simpleName.SyntaxTree;
-            return syntaxTree.GetRoot(cancellationToken).ReplaceNode(simpleName, qualifiedName);
+            var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+            return root.ReplaceNode(simpleName, qualifiedName);
         }
     }
 }

--- a/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
+++ b/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,10 +21,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractInterface
     [ExportLanguageService(typeof(AbstractExtractInterfaceService), LanguageNames.CSharp), Shared]
     internal sealed class CSharpExtractInterfaceService : AbstractExtractInterfaceService
     {
-        internal override SyntaxNode GetTypeDeclaration(Document document, int position, TypeDiscoveryRule typeDiscoveryRule, CancellationToken cancellationToken)
+        internal override async Task<SyntaxNode> GetTypeDeclarationAsync(Document document, int position, TypeDiscoveryRule typeDiscoveryRule, CancellationToken cancellationToken)
         {
-            var tree = document.GetSyntaxTreeAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var token = tree.GetRoot(cancellationToken).FindToken(position != tree.Length ? position : Math.Max(0, position - 1));
+            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+            var token = root.FindToken(position != tree.Length ? position : Math.Max(0, position - 1));
             var typeDeclaration = token.GetAncestor<TypeDeclarationSyntax>();
 
             if (typeDeclaration == null ||

--- a/src/Features/Core/Portable/CodeFixes/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
 
         protected abstract bool IgnoreCase { get; }
         protected abstract bool CanFullyQualify(Diagnostic diagnostic, ref SyntaxNode node);
-        protected abstract SyntaxNode ReplaceNode(SyntaxNode node, string containerName, CancellationToken cancellationToken);
+        protected abstract Task<SyntaxNode> ReplaceNodeAsync(SyntaxNode node, string containerName, CancellationToken cancellationToken);
 
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -96,10 +96,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
             }
         }
 
-        private Task<Document> ProcessNode(Document document, SyntaxNode node, string containerName, CancellationToken cancellationToken)
+        private async Task<Document> ProcessNode(Document document, SyntaxNode node, string containerName, CancellationToken cancellationToken)
         {
-            var newRoot = this.ReplaceNode(node, containerName, cancellationToken);
-            return Task.FromResult(document.WithSyntaxRoot(newRoot));
+            var newRoot = await this.ReplaceNodeAsync(node, containerName, cancellationToken).ConfigureAwait(false);
+            return document.WithSyntaxRoot(newRoot);
         }
 
         internal async Task<IEnumerable<ISymbol>> GetMatchingTypesAsync(

--- a/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
+++ b/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
 {
     internal abstract class AbstractExtractInterfaceService : ILanguageService
     {
-        internal abstract SyntaxNode GetTypeDeclaration(
+        internal abstract Task<SyntaxNode> GetTypeDeclarationAsync(
             Document document,
             int position,
             TypeDiscoveryRule typeDiscoveryRule,
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
             TypeDiscoveryRule typeDiscoveryRule,
             CancellationToken cancellationToken)
         {
-            var typeNode = GetTypeDeclaration(document, position, typeDiscoveryRule, cancellationToken);
+            var typeNode = await GetTypeDeclarationAsync(document, position, typeDiscoveryRule, cancellationToken).ConfigureAwait(false);
             if (typeNode == null)
             {
                 var errorMessage = FeaturesResources.CouldNotExtractInterfaceSelection;

--- a/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -290,14 +290,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
             Return symbol IsNot Nothing AndAlso symbol.Locations.Length > 0
         End Function
 
-        Protected Overloads Overrides Function AddImportAsync(
+        Protected Overloads Overrides Async Function AddImportAsync(
                 contextNode As SyntaxNode,
                 symbol As INamespaceOrTypeSymbol,
                 document As Document,
                 placeSystemNamespaceFirst As Boolean,
                 cancellationToken As CancellationToken) As Task(Of Document)
 
-            Dim root = DirectCast(contextNode.SyntaxTree.GetRoot(cancellationToken), CompilationUnitSyntax)
+            Dim root = DirectCast(Await contextNode.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(False), CompilationUnitSyntax)
 
             Dim memberImportsClause =
                 SyntaxFactory.SimpleImportsClause(name:=DirectCast(symbol.GenerateTypeSyntax(addGlobal:=False), NameSyntax).WithAdditionalAnnotations(Simplifier.Annotation))
@@ -305,10 +305,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
                 importsClauses:=SyntaxFactory.SingletonSeparatedList(Of ImportsClauseSyntax)(memberImportsClause))
 
             Dim syntaxTree = contextNode.SyntaxTree
-            Return Task.FromResult(
-                document.WithSyntaxRoot(
+            Return document.WithSyntaxRoot(
                 root.AddImportsStatement(newImport, placeSystemNamespaceFirst,
-                                         CaseCorrector.Annotation, Formatter.Annotation)))
+                                         CaseCorrector.Annotation, Formatter.Annotation))
         End Function
 
         Protected Overrides Function IsViableExtensionMethod(method As IMethodSymbol,

--- a/src/Features/VisualBasic/Portable/CodeFixes/FullyQualify/VisualBasicFullyQualifyCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/FullyQualify/VisualBasicFullyQualifyCodeFixProvider.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.FullyQualify
             Return Nothing
         End Function
 
-        Protected Overrides Function ReplaceNode(node As SyntaxNode, containerName As String, cancellationToken As CancellationToken) As SyntaxNode
+        Protected Overrides Async Function ReplaceNodeAsync(node As SyntaxNode, containerName As String, cancellationToken As CancellationToken) As Task(Of SyntaxNode)
             Dim simpleName = DirectCast(node, SimpleNameSyntax)
 
             Dim leadingTrivia = simpleName.GetLeadingTrivia()
@@ -99,7 +99,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.FullyQualify
             qualifiedName = qualifiedName.WithAdditionalAnnotations(Formatter.Annotation, CaseCorrector.Annotation)
 
             Dim tree = simpleName.SyntaxTree
-            Return tree.GetRoot(cancellationToken).ReplaceNode(simpleName, qualifiedName)
+            Dim root = Await tree.GetRootAsync(cancellationToken).ConfigureAwait(False)
+            Return root.ReplaceNode(simpleName, qualifiedName)
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/ExtractInterface/VisualBasicExtractInterfaceService.vb
+++ b/src/Features/VisualBasic/Portable/ExtractInterface/VisualBasicExtractInterfaceService.vb
@@ -14,13 +14,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractInterface
     Friend Class VisualBasicExtractInterfaceService
         Inherits AbstractExtractInterfaceService
 
-        Friend Overrides Function GetTypeDeclaration(
+        Friend Overrides Async Function GetTypeDeclarationAsync(
             document As Document, position As Integer,
             typeDiscoveryRule As TypeDiscoveryRule,
-            cancellationToken As CancellationToken) As SyntaxNode
+            cancellationToken As CancellationToken) As Task(Of SyntaxNode)
 
-            Dim tree = document.GetSyntaxTreeAsync(cancellationToken).WaitAndGetResult(cancellationToken)
-            Dim token = tree.GetRoot(cancellationToken).FindToken(If(position <> tree.Length, position, Math.Max(0, position - 1)))
+            Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
+            Dim root = Await tree.GetRootAsync(cancellationToken).ConfigureAwait(False)
+            Dim token = root.FindToken(If(position <> tree.Length, position, Math.Max(0, position - 1)))
             Dim typeDeclaration = token.GetAncestor(Of TypeBlockSyntax)()
 
             If typeDeclaration Is Nothing OrElse

--- a/src/Workspaces/CSharpTest/CodeGeneration/SymbolEditorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SymbolEditorTests.cs
@@ -305,7 +305,7 @@ internal partial class C
 }";
 
             var solution = GetSolution(code1, code2);
-            var comp = solution.Projects.First().GetCompilationAsync().Result;
+            var comp = await solution.Projects.First().GetCompilationAsync();
             var symbol = comp.GlobalNamespace.GetMembers("C").First();
 
             var editor = SymbolEditor.Create(solution);

--- a/src/Workspaces/CSharpTest/Formatting/FormattingMultipleSpanTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingMultipleSpanTests.cs
@@ -165,7 +165,7 @@ class A { }";
                 var document = project.AddDocument("Document", SourceText.From(""));
 
                 var syntaxTree = await document.GetSyntaxTreeAsync();
-                var result = await Formatter.FormatAsync(syntaxTree.GetRoot(CancellationToken.None), TextSpan.FromBounds(0, 0), workspace, cancellationToken: CancellationToken.None);
+                var result = await Formatter.FormatAsync(await syntaxTree.GetRootAsync(), TextSpan.FromBounds(0, 0), workspace, cancellationToken: CancellationToken.None);
             }
         }
 

--- a/src/Workspaces/Core/Portable/CodeCleanup/Providers/FormatCodeCleanupProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/Providers/FormatCodeCleanupProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                     return root;
                 }
 
-                return root.SyntaxTree.WithChangedText(oldText.WithChanges(changes)).GetRoot(cancellationToken);
+                return await root.SyntaxTree.WithChangedText(oldText.WithChanges(changes)).GetRootAsync(cancellationToken).ConfigureAwait(false);
             }
 
             return await Formatter.FormatAsync(root, spans, workspace, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
+++ b/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editing
             options = options ?? document.Project.Solution.Workspace.Options;
 
             var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var root = model.SyntaxTree.GetRoot();
+            var root = await model.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
 
             // Create a simple interval tree for simplification spans.
             var spansTree = new SimpleIntervalTree<TextSpan>(TextSpanIntervalIntrospector.Instance, spans);
@@ -39,23 +39,24 @@ namespace Microsoft.CodeAnalysis.Editing
             var newDoc = document.WithSyntaxRoot(newRoot);
             var newModel = await newDoc.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-            newRoot = this.AddNamespaceImports(newDoc, newModel, options, namespacesToAdd);
+            newRoot = await this.AddNamespaceImportsAsync(newDoc, newModel, options, namespacesToAdd, cancellationToken).ConfigureAwait(false);
             return document.WithSyntaxRoot(newRoot);
         }
 
-        private SyntaxNode AddNamespaceImports(
+        private async Task<SyntaxNode> AddNamespaceImportsAsync(
             Document document,
             SemanticModel model,
             OptionSet options,
-            IEnumerable<INamespaceSymbol> namespaces)
+            IEnumerable<INamespaceSymbol> namespaces,
+            CancellationToken cancellationToken)
         {
             var existingNamespaces = new HashSet<INamespaceSymbol>();
-            this.GetExistingImportedNamespaces(document, model, existingNamespaces);
+            await this.GetExistingImportedNamespacesAsync(document, model, existingNamespaces, cancellationToken).ConfigureAwait(false);
 
             var namespacesToAdd = new HashSet<INamespaceSymbol>(namespaces);
             namespacesToAdd.RemoveAll(existingNamespaces);
 
-            var root = model.SyntaxTree.GetRoot();
+            var root = await model.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
             if (namespacesToAdd.Count == 0)
             {
                 return root;
@@ -72,11 +73,15 @@ namespace Microsoft.CodeAnalysis.Editing
             return newRoot;
         }
 
-        protected virtual void GetExistingImportedNamespaces(Document document, SemanticModel model, HashSet<INamespaceSymbol> namespaces)
+        protected virtual async Task GetExistingImportedNamespacesAsync(
+            Document document,
+            SemanticModel model,
+            HashSet<INamespaceSymbol> namespaces,
+            CancellationToken cancellationToken)
         {
             // only consider top level imports
             var gen = SyntaxGenerator.GetGenerator(document);
-            var root = model.SyntaxTree.GetRoot();
+            var root = await model.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
             var imports = gen.GetNamespaceImports(root);
 
             var symbols = imports.Select(imp => GetImportedNamespaceSymbol(imp, model))

--- a/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
+++ b/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Simplification
                 // Hence make sure we always start working off of the actual SemanticModel instead of a speculative SemanticModel.
                 Contract.Assert(!semanticModel.IsSpeculativeSemanticModel);
 
-                var root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
+                var root = await semanticModel.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
 
 #if DEBUG
                 bool originalDocHasErrors = await document.HasAnyErrorsAsync(cancellationToken).ConfigureAwait(false);
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Simplification
                 !spansTree.GetOverlappingIntervals(nodeOrToken.FullSpan.Start, nodeOrToken.FullSpan.Length).Any();
 
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
+            var root = await semanticModel.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
 
             // prep namespace imports marked for simplification 
             var removeIfUnusedAnnotation = new SyntaxAnnotation();
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Simplification
             {
                 document = document.WithSyntaxRoot(root);
                 semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
+                root = await semanticModel.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
             }
 
             // Get the list of syntax nodes and tokens that need to be reduced.
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.Simplification
             CancellationToken cancellationToken)
         {
             var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var root = model.SyntaxTree.GetRoot();
+            var root = await model.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
             var addedImports = root.GetAnnotatedNodes(removeIfUnusedAnnotation);
             var unusedImports = new HashSet<SyntaxNode>();
             this.GetUnusedNamespaceImports(model, unusedImports, cancellationToken);

--- a/src/Workspaces/CoreTest/CodeCleanup/CodeCleanupTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/CodeCleanupTests.cs
@@ -75,13 +75,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
         }
 
         [Fact]
-        public void CodeCleaners_Annotation()
+        public async Task CodeCleaners_Annotation()
         {
             var document = CreateDocument("class C { }", LanguageNames.CSharp);
             var annotation = new SyntaxAnnotation();
-            document = document.WithSyntaxRoot(document.GetSyntaxRootAsync().Result.WithAdditionalAnnotations(annotation));
+            document = document.WithSyntaxRoot((await document.GetSyntaxRootAsync()).WithAdditionalAnnotations(annotation));
 
-            var cleanDocument = CodeCleaner.CleanupAsync(document, annotation).Result;
+            var cleanDocument = await CodeCleaner.CleanupAsync(document, annotation);
 
             Assert.Equal(document, cleanDocument);
         }

--- a/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
@@ -1464,7 +1464,7 @@ End Class";
 
             var cleanDocument = await CodeCleaner.CleanupAsync(document, textSpans[0], codeCleanups);
 
-            Assert.Equal(expectedResult, cleanDocument.GetSyntaxRootAsync().Result.ToFullString());
+            Assert.Equal(expectedResult, (await cleanDocument.GetSyntaxRootAsync()).ToFullString());
         }
 
         private static Document CreateDocument(string code, string language, LanguageVersion langVersion)

--- a/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
+++ b/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
@@ -361,21 +361,21 @@ Inner i;
         }
 
         [Fact]
-        public static void FindSourceDeclarationsAsync_Solution_Test_NullProject()
+        public static async Task FindSourceDeclarationsAsync_Solution_Test_NullProject()
         {
-            Assert.Throws<ArgumentNullException>(() =>
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                var declarations = SymbolFinder.FindSourceDeclarationsAsync((Solution)null, "Test", true).Result;
+                var declarations = await SymbolFinder.FindSourceDeclarationsAsync((Solution)null, "Test", true);
             });
         }
 
         [Fact]
-        public static void FindSourceDeclarationsAsync_Solution_Test_NullString()
+        public static async Task FindSourceDeclarationsAsync_Solution_Test_NullString()
         {
-            Assert.Throws<ArgumentNullException>(() =>
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
                 var solution = GetSolution(WorkspaceKind.SingleClass);
-                var declarations = SymbolFinder.FindSourceDeclarationsAsync(solution, null, true).Result;
+                var declarations = await SymbolFinder.FindSourceDeclarationsAsync(solution, null, true);
             });
         }
 

--- a/src/Workspaces/CoreTest/Formatting/FormattingTestBase.cs
+++ b/src/Workspaces/CoreTest/Formatting/FormattingTestBase.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Formatting
                     }
                 }
 
-                var root = syntaxTree.GetRoot();
+                var root = await syntaxTree.GetRootAsync();
                 await AssertFormatAsync(workspace, expected, root, spans, options, await document.GetTextAsync());
 
                 // format with node and transform

--- a/src/Workspaces/VisualBasicTest/Formatting/VisualBasicFormattingTestBase.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/VisualBasicFormattingTestBase.vb
@@ -49,16 +49,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Formatting
                 Dim spans = New List(Of TextSpan)()
                 spans.Add(syntaxTree.GetRoot().FullSpan)
 
-                Dim changes = Await Formatter.GetFormattedTextChangesAsync(syntaxTree.GetRoot(CancellationToken.None), workspace, cancellationToken:=CancellationToken.None).ConfigureAwait(True)
+                Dim changes = Await Formatter.GetFormattedTextChangesAsync(Await syntaxTree.GetRootAsync(), workspace, cancellationToken:=CancellationToken.None).ConfigureAwait(True)
                 AssertResult(expected, Await document.GetTextAsync(), changes)
 
-                changes = Await Formatter.GetFormattedTextChangesAsync(syntaxTree.GetRoot(), syntaxTree.GetRoot(CancellationToken.None).FullSpan, workspace, cancellationToken:=CancellationToken.None).ConfigureAwait(True)
+                changes = Await Formatter.GetFormattedTextChangesAsync(Await syntaxTree.GetRootAsync(), (Await syntaxTree.GetRootAsync()).FullSpan, workspace, cancellationToken:=CancellationToken.None).ConfigureAwait(True)
                 AssertResult(expected, Await document.GetTextAsync(), changes)
 
                 spans = New List(Of TextSpan)()
                 spans.Add(syntaxTree.GetRoot().FullSpan)
 
-                changes = Await Formatter.GetFormattedTextChangesAsync(syntaxTree.GetRoot(CancellationToken.None), spans, workspace, cancellationToken:=CancellationToken.None).ConfigureAwait(True)
+                changes = Await Formatter.GetFormattedTextChangesAsync(Await syntaxTree.GetRootAsync(), spans, workspace, cancellationToken:=CancellationToken.None).ConfigureAwait(True)
                 AssertResult(expected, Await document.GetTextAsync(), changes)
 
                 ' format with node and transform


### PR DESCRIPTION
Also reduce cascaded diagnostics in lambdas inside queries.
Fixes #1867
