### PR TITLE
Eliminate a parameter that is the same among all callers.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2644,7 +2644,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var boundConstantPattern = BindConstantPattern(
-                    node.Right, operand, operand.Type, node.Right, node.Right.HasErrors, isPatternDiagnostics, out wasExpression, wasSwitchCase: false);
+                    node.Right, operand.Type, node.Right, node.Right.HasErrors, isPatternDiagnostics, out wasExpression, wasSwitchCase: false);
                 if (wasExpression)
                 {
                     isTypeDiagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -27,14 +27,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            var pattern = BindPattern(node.Pattern, expression, expressionType, hasErrors, diagnostics);
+            var pattern = BindPattern(node.Pattern, expressionType, hasErrors, diagnostics);
             return new BoundIsPatternExpression(
                 node, expression, pattern, GetSpecialType(SpecialType.System_Boolean, diagnostics, node), hasErrors);
         }
 
         internal BoundPattern BindPattern(
             PatternSyntax node,
-            BoundExpression operand,
             TypeSymbol operandType,
             bool hasErrors,
             DiagnosticBag diagnostics,
@@ -44,11 +43,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case SyntaxKind.DeclarationPattern:
                     return BindDeclarationPattern(
-                        (DeclarationPatternSyntax)node, operand, operandType, hasErrors, diagnostics);
+                        (DeclarationPatternSyntax)node, operandType, hasErrors, diagnostics);
 
                 case SyntaxKind.ConstantPattern:
                     return BindConstantPattern(
-                        (ConstantPatternSyntax)node, operand, operandType, hasErrors, diagnostics, wasSwitchCase);
+                        (ConstantPatternSyntax)node, operandType, hasErrors, diagnostics, wasSwitchCase);
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(node.Kind());
@@ -57,19 +56,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundConstantPattern BindConstantPattern(
             ConstantPatternSyntax node,
-            BoundExpression operand,
             TypeSymbol operandType,
             bool hasErrors,
             DiagnosticBag diagnostics,
             bool wasSwitchCase)
         {
             bool wasExpression;
-            return BindConstantPattern(node, operand, operandType, node.Expression, hasErrors, diagnostics, out wasExpression, wasSwitchCase);
+            return BindConstantPattern(node, operandType, node.Expression, hasErrors, diagnostics, out wasExpression, wasSwitchCase);
         }
 
         internal BoundConstantPattern BindConstantPattern(
             CSharpSyntaxNode node,
-            BoundExpression operand,
             TypeSymbol operandType,
             ExpressionSyntax patternExpression,
             bool hasErrors,
@@ -133,7 +130,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private bool CheckValidPatternType(
             CSharpSyntaxNode typeSyntax,
-            BoundExpression operand,
             TypeSymbol operandType,
             TypeSymbol patternType,
             bool patternTypeWasInSource,
@@ -142,10 +138,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert((object)operandType != null);
             Debug.Assert((object)patternType != null);
-
-            // Because we do not support recursive patterns, we always have an operand
-            Debug.Assert((object)operand != null);
-            // Once we support recursive patterns that will be relaxed.
 
             if (operandType.IsErrorType() || patternType.IsErrorType())
             {
@@ -171,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                var matchPossible = ExpressionOfTypeMatchesPatternType(Conversions, operandType, patternType, ref useSiteDiagnostics, out Conversion conversion, operandConstantValue: null, operandCouldBeNull: true);
+                var matchPossible = ExpressionOfTypeMatchesPatternType(Conversions, operandType, patternType, ref useSiteDiagnostics, out Conversion conversion, operandCouldBeNull: true);
                 diagnostics.Add(typeSyntax, useSiteDiagnostics);
                 if (matchPossible != false)
                 {
@@ -211,7 +203,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol patternType,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics,
             out Conversion conversion,
-            ConstantValue operandConstantValue = null,
             bool operandCouldBeNull = false)
         {
             Debug.Assert((object)expressionType != null);
@@ -222,6 +213,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             conversion = conversions.ClassifyConversionFromType(expressionType, patternType, ref useSiteDiagnostics);
+            const ConstantValue operandConstantValue = null; // subsumption always ignores the *value* of the expression.
             var result = Binder.GetIsOperatorConstantResult(expressionType, patternType, conversion.Kind, operandConstantValue, operandCouldBeNull);
             return
                 (result == null) ? (bool?)null :
@@ -232,12 +224,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundPattern BindDeclarationPattern(
             DeclarationPatternSyntax node,
-            BoundExpression operand,
             TypeSymbol operandType,
             bool hasErrors,
             DiagnosticBag diagnostics)
         {
-            Debug.Assert(operand != null && operandType != (object)null);
+            Debug.Assert(operandType != (object)null);
 
             var typeSyntax = node.Type;
 
@@ -262,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                hasErrors |= CheckValidPatternType(typeSyntax, operand, operandType, declType,
+                hasErrors |= CheckValidPatternType(typeSyntax, operandType, declType,
                                                    isVar: isVar, patternTypeWasInSource: true, diagnostics: diagnostics);
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/PatternSwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternSwitchBinder.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var caseLabelSyntax = (CaseSwitchLabelSyntax)node;
                         bool wasExpression;
                         var pattern = sectionBinder.BindConstantPattern(
-                            node, boundSwitchExpression, boundSwitchExpression.Type, caseLabelSyntax.Value, node.HasErrors, diagnostics, out wasExpression, wasSwitchCase: true);
+                            node, boundSwitchExpression.Type, caseLabelSyntax.Value, node.HasErrors, diagnostics, out wasExpression, wasSwitchCase: true);
                         bool hasErrors = pattern.HasErrors;
                         var constantValue = pattern.ConstantValue;
                         if (!hasErrors &&
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var matchLabelSyntax = (CasePatternSwitchLabelSyntax)node;
                         var pattern = sectionBinder.BindPattern(
-                            matchLabelSyntax.Pattern, boundSwitchExpression, boundSwitchExpression.Type, node.HasErrors, diagnostics, wasSwitchCase: true);
+                            matchLabelSyntax.Pattern, boundSwitchExpression.Type, node.HasErrors, diagnostics, wasSwitchCase: true);
                         return new BoundPatternSwitchLabel(node, label, pattern,
                             matchLabelSyntax.WhenClause != null ? sectionBinder.BindBooleanExpression(matchLabelSyntax.WhenClause.Condition, diagnostics) : null,
                             true, node.HasErrors);

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // bind the pattern, to cause its pattern variables to be inferred if necessary
                         var matchLabel = (CasePatternSwitchLabelSyntax)labelSyntax;
                         var pattern = sectionBinder.BindPattern(
-                            matchLabel.Pattern, SwitchGoverningExpression, SwitchGoverningType, labelSyntax.HasErrors, tempDiagnosticBag, wasSwitchCase: true);
+                            matchLabel.Pattern, SwitchGoverningType, labelSyntax.HasErrors, tempDiagnosticBag, wasSwitchCase: true);
                         break;
 
                     default:

--- a/src/Compilers/CSharp/Portable/BoundTree/DecisionTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DecisionTreeBuilder.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal bool? ExpressionOfTypeMatchesPatternType(TypeSymbol expressionType, TypeSymbol patternType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            return Binder.ExpressionOfTypeMatchesPatternType(this._conversions, expressionType, patternType, ref _useSiteDiagnostics, out Conversion conversion, null, false);
+            return Binder.ExpressionOfTypeMatchesPatternType(this._conversions, expressionType, patternType, ref _useSiteDiagnostics, out Conversion conversion, operandCouldBeNull: false);
         }
 
         private DecisionTree AddByType(DecisionTree decision, TypeSymbol type, DecisionMaker makeDecision)


### PR DESCRIPTION
Also eliminate unused parameters.

This PR shows a slight code improvement that we can make after 15.3.
