### PR TITLE
Fixing WhenKeywordRecommender to understand var pattern

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/WhenKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/WhenKeywordRecommenderTests.cs
@@ -426,6 +426,33 @@ class C
 }");
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestForSwitchCase_SemanticCheck_NotAfterTypeAliasVar() =>
+    await VerifyAbsenceAsync(@"
+using var = System.String;
+class C
+{
+    void M() { switch (new object()) { case var $$ } }
+}");
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestForSwitchCase_SemanticCheck_NotAfterTypeAliasVar_BeforeBreak() =>
+            await VerifyAbsenceAsync(@"
+using var = System.String;
+class C
+{
+    void M() { switch (new object()) { case var $$ break; } }
+}");
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestForSwitchCase_SemanticCheck_NotAfterTypeAliasVar_BeforeWhen() =>
+            await VerifyAbsenceAsync(@"
+using var = System.String;
+class C
+{
+    void M() { switch (new object()) { case var $$ when } }
+}");
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestForSwitchCase_SemanticCheck_AfterLocalConstantVar() =>
             await VerifyKeywordAsync(AddInsideMethod(@"const object var = null; switch (new object()) { case var $$ }"));
 
@@ -462,6 +489,36 @@ class var { }
 class C
 {
     void M() { const object var = null; switch (new object()) { case var $$ when } }
+}");
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestForSwitchCase_SemanticCheck_AfterTypeAliasAndFieldConstantVar() =>
+    await VerifyKeywordAsync(@"
+using var = System.String;
+class C
+{
+    const object var = null;
+    void M() { switch (new object()) { case var $$ } }
+}");
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestForSwitchCase_SemanticCheck_AfterTypeAliasAndFieldConstantVar_BeforeBreak() =>
+    await VerifyKeywordAsync(@"
+using var = System.String;
+class C
+{
+    const object var = null;
+    void M() { switch (new object()) { case var $$ break; } }
+}");
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestForSwitchCase_SemanticCheck_AfterTypeAliasAndFieldConstantVar_BeforeWhen() =>
+    await VerifyKeywordAsync(@"
+using var = System.String;
+class C
+{
+    const object var = null;
+    void M() { switch (new object()) { case var $$ when } }
 }");
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WhenKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WhenKeywordRecommender.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -24,16 +25,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         private static bool IsAfterCompleteExpressionOrPatternInCaseLabel(CSharpSyntaxContext context,
-            out SyntaxNode expressionOrPattern)
+            out SyntaxNodeOrToken nodeOrToken)
         {
+            nodeOrToken = null;
+
             var switchLabel = context.TargetToken.GetAncestor<SwitchLabelSyntax>();
             if (switchLabel == null)
             {
-                expressionOrPattern = null;
                 return false;
             }
 
-            expressionOrPattern = switchLabel.ChildNodes().FirstOrDefault();
+            var expressionOrPattern = switchLabel.ChildNodes().FirstOrDefault();
             if (expressionOrPattern == null)
             {
                 // It must have been a default label.
@@ -61,6 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             var lastToken = expressionOrPattern.GetLastToken(includeZeroWidth: false);
             if (lastToken == context.TargetToken)
             {
+                nodeOrToken = expressionOrPattern;
                 return true;
             }
 
@@ -78,7 +81,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     // However 'constant' itself might end up being a valid constant pattern.
                     // We will pretend as if 'w' didn't exist so that the later check
                     // for whether 'constant' is actually a type can still work properly.
-                    expressionOrPattern = declarationPattern.Type;
+                    nodeOrToken = declarationPattern.Type;
+                    return true;
+                }
+
+                if (expressionOrPattern is VarPatternSyntax varPattern)
+                {
+                    // The new token causes this to be parsed as a var pattern:
+                    // case var w| ('w' = LeftToken, 'var' = TargetToken)
+
+                    // However 'var' itself might end up being a valid constant pattern.
+                    nodeOrToken = varPattern.VarKeyword;
                     return true;
                 }
 
@@ -88,6 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     // case { } w| ('w' = LeftToken, '}' = TargetToken)
 
                     // However the identifier is optional and can be replaced by 'when'.
+                    nodeOrToken = recursivePattern.Type;
                     return true;
                 }
 
@@ -98,7 +112,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             return false;
         }
 
-        private static bool IsTypeName(SyntaxNode expressionOrPattern, SemanticModel semanticModel,
+        private static bool IsTypeName(
+            SyntaxNodeOrToken nodeOrToken,
+            SemanticModel semanticModel,
             CancellationToken cancellationToken)
         {
             // Syntactically, everything works out. We're in a pretty good spot to show 'when' now.
@@ -108,22 +124,38 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             // If what we have here is known to be a type, we don't want to clutter the variable name suggestion list
             // with 'when' since we know that the resulting code would be semantically invalid.
 
-            var expression = expressionOrPattern as ExpressionSyntax
-                ?? (expressionOrPattern as ConstantPatternSyntax)?.Expression;
-            
-            if (!(expression is TypeSyntax typeSyntax))
+            bool isVar;
+            ImmutableArray<ISymbol> symbols;
+
+            if (nodeOrToken.IsNode)
             {
-                return false;
+                var node = nodeOrToken.AsNode();
+                var expression = node as ExpressionSyntax
+                    ?? (node as ConstantPatternSyntax)?.Expression;
+
+                if (!(expression is TypeSyntax typeSyntax))
+                {
+                    return false;
+                }
+
+                // We don't pass in the semantic model - let IsPotentialTypeName handle the cases where it's clear
+                // from the syntax, but other than that, we need to do our own logic here.
+                if (typeSyntax.IsPotentialTypeName(semanticModelOpt: null, cancellationToken))
+                {
+                    return true;
+                }
+
+                isVar = typeSyntax.IsVar;
+                symbols = semanticModel.LookupName(typeSyntax, namespacesAndTypesOnly: false, cancellationToken);
+            }
+            else
+            {
+                var token = nodeOrToken.AsToken();
+
+                isVar = token.Text == SyntaxFacts.GetText(SyntaxKind.VarKeyword);
+                symbols = semanticModel.LookupSymbols(nodeOrToken.AsToken().SpanStart, null, token.Text);
             }
 
-            // We don't pass in the semantic model - let IsPotentialTypeName handle the cases where it's clear
-            // from the syntax, but other than that, we need to do our own logic here.
-            if (typeSyntax.IsPotentialTypeName(semanticModelOpt: null, cancellationToken))
-            {
-                return true;
-            }
-
-            var symbols = semanticModel.LookupName(typeSyntax, namespacesAndTypesOnly: false, cancellationToken);
             if (symbols.Length == 0)
             {
                 // For all unknown identifiers except var, we return false (therefore 'when' will be offered),
@@ -132,9 +164,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 // assumption that the user didn't just type 'var' to then create a constant named 'var', but really
                 // is about to declare a variable. Therefore we don't want to interfere with the declaration.
                 // However note that if such a constant already exists, we do the right thing and do offer 'when'.
-                return typeSyntax.IsVar;
+                return isVar;
             }
-            
+
             return symbols.All(symbol => symbol is IAliasSymbol || symbol is ITypeSymbol);
         }
     }


### PR DESCRIPTION
@gafter Should we do it this way? Or will you just skip the tests so I can then make a separate PR into dotnet/roslyn?